### PR TITLE
Makefile fixes

### DIFF
--- a/RPi/RF24/Makefile
+++ b/RPi/RF24/Makefile
@@ -46,7 +46,7 @@ bcm2835.o: bcm2835.c
 clean:
 	rm -rf *.o ${LIB}.*
 
-install: install-libs install-headers
+install: all install-libs install-headers
 
 # Install the library to LIBPATH
 install-libs: 

--- a/RPi/RF24/readme.md
+++ b/RPi/RF24/readme.md
@@ -39,7 +39,6 @@ C.  Copy the RPi library folder to the current directory, and delete the rest
 
 D. Build the library, and run an example file:  
 
-    make  
     sudo make install
     cd examples  
     make


### PR DESCRIPTION
Few fixes to Makefile:
- Separate out install from build so un-privileged user can build
- Install header files to /usr/local/include/RF24 for easy inclusion when using this library: i.e. `#include <RF24.h>`
- Updated readme.md to reflect changes
- Cleaned up readme.md while I was in there
  - Use consistent syntax for headers
  - Tabs -> Spaces
  - Indent code by 4 spaces rather than using backticks
  - Fix table so it renders correctly in github
