### PR TITLE
character fix

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -314,7 +314,7 @@ void RF24::print_observe_tx(uint8_t value)
 
 void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
+  char extra_tab = strlen_P(name) < 8 ? '\t' : '\a';
   printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
   while (qty--)
     printf_P(PSTR(" 0x%02x"),read_register(reg++));
@@ -325,7 +325,7 @@ void RF24::print_byte_register(const char* name, uint8_t reg, uint8_t qty)
 
 void RF24::print_address_register(const char* name, uint8_t reg, uint8_t qty)
 {
-  char extra_tab = strlen_P(name) < 8 ? '\t' : 0;
+  char extra_tab = strlen_P(name) < 8 ? '\t' : '\a';
   printf_P(PSTR(PRIPSTR"\t%c ="),name,extra_tab);
 
   while (qty--)


### PR DESCRIPTION
I had really strange characters in the `printDetails()` on Arduino Serial monitor on MacOS as shown here:
![screen shot 2014-10-14 at 21 57 03](https://cloud.githubusercontent.com/assets/727711/4635741/b397b78c-53dc-11e4-9b98-de64085fef6d.png)

After applying the patch (replacing 0-Byte with a Ring-Bell-but-do-nothing-Byte) the text is shown correctly.

![screen shot 2014-10-14 at 21 58 20](https://cloud.githubusercontent.com/assets/727711/4635783/24e8900a-53dd-11e4-8576-5418f61b72e7.png)
