### PR TITLE
Proposing a fix for #272.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -693,6 +693,19 @@ bool RF24::begin(void)
 
 /****************************************************************************/
 
+bool RF24::isChipConnected()
+{
+  uint8_t setup = read_register(SETUP_AW);
+  if(setup >= 1 && setup <= 3)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+/****************************************************************************/
+
 void RF24::startListening(void)
 {
  #if !defined (RF24_TINY) && ! defined(LITTLEWIRE)

--- a/RF24.h
+++ b/RF24.h
@@ -138,6 +138,11 @@ public:
   bool begin(void);
 
   /**
+   * Checks if the chip is connected to the SPI bus
+   */
+  bool isChipConnected();
+
+  /**
    * Start listening on the pipes opened for reading.
    *
    * 1. Be sure to call openReadingPipe() first.  


### PR DESCRIPTION
When SETUP_AW contains a value 1 or 2 or 3 then it is ok (according to the specification). I have hardcoded those values in the "if" condition. I could expose a new bit mnemonics for SETUP_AW (however mnemonic AW already exist) and use that _BV macro? I do not know which is better.
