### PR TITLE
Added implementation for wiringPi driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ else ifeq ($(DRIVER), RPi)
 OBJECTS+=spi.o bcm2835.o interrupt.o
 else ifeq ($(DRIVER), SPIDEV)
 OBJECTS+=spi.o gpio.o compatibility.o interrupt.o
+else ifeq ($(DRIVER), wiringPi)
+OBJECTS+=spi.o
 endif
 
 # make all

--- a/configure
+++ b/configure
@@ -12,7 +12,7 @@ Help:
     -h, --help                  print this message
 
 Driver options:
-    --driver=[SPIDEV|MRAA|RPi|LittleWire]
+    --driver=[wiringPi|SPIDEV|MRAA|RPi|LittleWire]
                                 Driver for RF24 library. [configure autodetected]
 
 Building options:
@@ -179,6 +179,8 @@ function detect_driver {
         result=RPi
     elif [[ $(execute_check 'ls /dev/spidev* 2>/dev/null') ]]; then
         result=SPIDEV
+    elif [[ $(execute_check "file /usr/lib/libwiringPi.so*") ]]; then
+        result=wiringPi
     elif [[ $(execute_check "${REMOTE_LDCONFIG} -p | grep libmraa") ]]; then
         result=MRAA
     elif [[ $(execute_check "${REMOTE_LDCONFIG} -p | grep liblittlewire-spi") ]]; then
@@ -395,6 +397,10 @@ if [ -z "${DRIVER}" ]; then
 fi
 
 case ${DRIVER} in
+wiringPi)
+    SHARED_LINKER_FLAGS+=" -pthread -lwiringPi"
+    CFLAGS+=" -lwiringPi"
+    ;;
 SPIDEV)
     SHARED_LINKER_FLAGS+=" -pthread"
     ;;

--- a/utility/wiringPi/RF24_arch_config.h
+++ b/utility/wiringPi/RF24_arch_config.h
@@ -1,0 +1,56 @@
+
+/*
+ Copyright (C) 2011 J. Coliz <maniacbug@ymail.com>
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License
+ version 2 as published by the Free Software Foundation.
+
+ */
+#ifndef __ARCH_CONFIG_H__
+#define __ARCH_CONFIG_H__
+
+#define RF24_LINUX
+
+#include <stddef.h>
+#include "spi.h"
+#include "wiringPi.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include <string.h>
+#include <sys/time.h>
+
+#define _BV(x) (1<<(x))
+#define _SPI spi
+
+#undef SERIAL_DEBUG
+#ifdef SERIAL_DEBUG
+#define IF_SERIAL_DEBUG(x) ({x;})
+#else
+#define IF_SERIAL_DEBUG(x)
+#endif
+
+// Avoid spurious warnings
+#if 1
+#if ! defined( NATIVE ) && defined( ARDUINO )
+#undef PROGMEM
+#define PROGMEM __attribute__(( section(".progmem.data") ))
+#undef PSTR
+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
+#endif
+#endif
+
+typedef uint16_t prog_uint16_t;
+#define PSTR(x) (x)
+#define printf_P printf
+#define strlen_P strlen
+#define PROGMEM
+#define pgm_read_word(p) (*(p))
+#define PRIPSTR "%s"
+#define pgm_read_byte(p) (*(p))
+
+#endif // __ARCH_CONFIG_H__
+
+
+/*@}*/

--- a/utility/wiringPi/includes.h
+++ b/utility/wiringPi/includes.h
@@ -1,0 +1,30 @@
+
+ /**
+ * @file includes.h
+ * Configuration defines for RF24/Linux
+ */
+
+ /**
+ * Example of includes.h for RF24 Linux portability
+ *
+ * @defgroup Porting_Includes Porting: Includes
+ *
+ *
+ * @{
+ */
+
+#ifndef __RF24_INCLUDES_H__
+#define __RF24_INCLUDES_H__
+
+  /**
+   * Define RF24_WIRINGPI configuration for RaspberryPi platform
+   */
+  #define RF24_WIRINGPI
+
+  /**
+   * Load the correct configuration for this platform
+   */
+  #include "wiringPi/RF24_arch_config.h"
+
+#endif
+/*@}*/

--- a/utility/wiringPi/spi.cpp
+++ b/utility/wiringPi/spi.cpp
@@ -1,0 +1,93 @@
+/*
+ * File:   spi.cpp
+ * Author:
+ *
+ * Created on
+ *
+ * Inspired from spi speed test from wiringPi
+ * wiringPi/examples/spiSpeed.c
+ */
+
+#include "spi.h"
+
+#include <wiringPi.h>
+#include <wiringPiSPI.h>
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+
+#define RF24_SPI_SPEED		8 * 1000000 // 8Mhz
+#define RF24_SPI_CHANNEL	0
+
+SPI::SPI():fd(-1)
+{
+    printf("wiringPi RF24 DRIVER\n");
+}
+
+void SPI::begin(int csn_pin)
+{
+    // initialize the wiringPiSPI
+    if ((this->fd = wiringPiSPISetup(RF24_SPI_CHANNEL, RF24_SPI_SPEED)) < 0)
+    {
+        printf("Cannot configure the SPI device!\n");
+        fflush(stdout);
+        abort();
+    }
+    else
+        printf("Configured SPI fd: %d - pin: %d\n", fd, csn_pin);
+}
+
+uint8_t SPI::transfer(uint8_t tx)
+{
+    memset(&msgByte, 0, sizeof(msgByte));
+    memcpy(&msgByte, &tx, sizeof(tx));
+
+    if(wiringPiSPIDataRW(RF24_SPI_CHANNEL, &msgByte, sizeof(tx)) < 0)
+    {
+        printf("transfer(): Cannot send data: %s\n", strerror(errno));
+        fflush(stdout);
+        abort();
+    }
+
+    return msgByte;
+}
+
+void SPI::transfern(char* buf, uint32_t len)
+{
+    printf("transfern(tx: %s)\n", buf);
+
+    if(wiringPiSPIDataRW(RF24_SPI_CHANNEL, (uint8_t *)buf, len) < 0)
+    {
+        printf("transfern(): Cannot send data %s\n", strerror(errno));
+        fflush(stdout);
+        abort();
+    }
+}
+
+void SPI::transfernb(char* tbuf, char* rbuf, uint32_t len)
+{
+    // using an auxiliary buffer to keep tx and rx different
+    memset(msg, 0, sizeof(msg));
+    memcpy(msg, tbuf, len);
+
+    if(wiringPiSPIDataRW(RF24_SPI_CHANNEL, msg, len) < 0)
+    {
+        printf("transfernb() Cannot send data %s\n", strerror(errno));
+        fflush(stdout);
+        abort();
+    }
+
+    memcpy(rbuf, msg, len);
+}
+
+SPI::~SPI()
+{
+    if (!(this->fd < 0))
+    {
+        close(this->fd);
+        this->fd = -1;
+    }
+}

--- a/utility/wiringPi/spi.h
+++ b/utility/wiringPi/spi.h
@@ -1,0 +1,70 @@
+
+/**
+ * @file spi.h
+ * Class declaration for SPI helper files
+ */
+
+#ifndef SPI_H
+#define	SPI_H
+
+ /**
+ * Example of spi.h class declaration for SPI portability
+ *
+ * @defgroup Porting_SPI Porting: SPI
+ *
+ * @{
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+using namespace std;
+class SPI {
+public:
+        /**
+        * SPI default constructor
+        */
+        SPI();
+
+        /**
+        * Start SPI communication
+        * @param pin used for SPI
+        */
+        void begin(int);
+
+        /**
+        * Transfer a single byte of data
+        * @param tx Byte to send
+        * @return Data returned via spi
+        */
+        uint8_t transfer(uint8_t);
+
+        /**
+        * Transfer a buffer of data using rx and tx buffer
+        * @param tbuf Transmit buffer
+        * @param rbuf Receive buffer
+        * @param len Length of the data
+        */
+        void transfernb(char*, char*, uint32_t);
+
+        /**
+        * Transfer a buffer of data without using an rx buffer
+        * @param buf Pointer to a buffer of data
+        * @param len Length of the data
+        */
+        void transfern(char*, const uint32_t);
+
+        /**
+        * SPI destructor
+        */
+        virtual ~SPI();
+
+private:
+        int fd;
+        uint8_t msg[32 + 1];
+        uint8_t msgByte;
+};
+
+/*@}*/
+#endif	/* SPI_H */
+


### PR DESCRIPTION
In case the wiringPi and the RF24 are used together in the same
application CPU load goes to 100%. The solution was to create a new
implementation based on the SPI from wiringPi library. In order to
have it working the wiringPi library should be already installed.
For enabling this implementation the "--driver=wiringPi" should be
considered when compiling the RF24.

Fixes the reported issues from #305 ticket.

Signed-off-by: Aurelian Z. <aurelian17@gmail.com>