### PR TITLE
Make flush_rx public

### DIFF
--- a/RF24.h
+++ b/RF24.h
@@ -984,6 +984,13 @@ s   *
    */
   void openWritingPipe(uint64_t address);
 
+  /**
+   * Empty the receive buffer
+   *
+   * @return Current value of status register
+   */
+  uint8_t flush_rx(void);
+
 private:
 
   /**
@@ -1073,13 +1080,6 @@ private:
    * @return Current value of status register
    */
   uint8_t read_payload(void* buf, uint8_t len);
-
-  /**
-   * Empty the receive buffer
-   *
-   * @return Current value of status register
-   */
-  uint8_t flush_rx(void);
 
   /**
    * Retrieve the current status of the chip


### PR DESCRIPTION
Since flush_rx was removed from startListening, this provides an option
to flush the RX buffer in use cases where this is required.

Related to issue #323 