### PR TITLE
Allow 4 wire mode on Arduino - set CSN pinMode properly when CE = CSN

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -613,7 +613,7 @@ bool RF24::begin(void)
     // Initialize pins
     if (ce_pin != csn_pin) pinMode(ce_pin,OUTPUT);  
   
-    #if ! defined(LITTLEWIRE)
+    #if defined(RF24_TINY)
       if (ce_pin != csn_pin)
     #endif
         pinMode(csn_pin,OUTPUT);

--- a/RF24.h
+++ b/RF24.h
@@ -984,6 +984,13 @@ s   *
    */
   void openWritingPipe(uint64_t address);
 
+  /**
+   * Empty the receive buffer
+   *
+   * @return Current value of status register
+   */
+  uint8_t flush_rx(void);
+
 private:
 
   /**
@@ -1073,13 +1080,6 @@ private:
    * @return Current value of status register
    */
   uint8_t read_payload(void* buf, uint8_t len);
-
-  /**
-   * Empty the receive buffer
-   *
-   * @return Current value of status register
-   */
-  uint8_t flush_rx(void);
 
   /**
    * Retrieve the current status of the chip


### PR DESCRIPTION
This pull request is showing multiple commits because I re-synced my fork to the master.  The only real change is the last commit (a one line change)