### PR TITLE
Fix for #369

### DIFF
--- a/RF24.h
+++ b/RF24.h
@@ -1473,14 +1473,28 @@ private:
  *
  * Setup:<br>
  * 1. Install the digitalIO library<br>
- * 2. Open RF24_config.h in a text editor. Uncomment the line #define SOFTSPI<br>
- * 3. In your sketch, add #include DigitalIO.h
+ * 2. Open RF24_config.h in a text editor. 
+      Uncomment the line 
+      @code
+      #define SOFTSPI
+      @endcode
+      or add the build flag/option
+      @code
+      -DSOFTSPI
+      @endcode
+ * 3. In your sketch, add
+ *     @code
+ *     #include DigitalIO.h
+ *     @endcode
  *
  * @note Note: Pins are listed as follows and can be modified by editing the RF24_config.h file<br>
  *
- *     const uint8_t SOFT_SPI_MISO_PIN = 16;
- *     const uint8_t SOFT_SPI_MOSI_PIN = 15;
- *     const uint8_t SOFT_SPI_SCK_PIN = 14;
+ *     #define SOFT_SPI_MISO_PIN 16
+ *     #define SOFT_SPI_MOSI_PIN 15
+ *     #define SOFT_SPI_SCK_PIN 14
+ * Or add the build flag/option
+ *
+ *     -DSOFT_SPI_MISO_PIN=16 -DSOFT_SPI_MOSI_PIN=15 -DSOFT_SPI_SCK_PIN=14
  *
  * <br>
  * **Alternate Hardware (UART) Driven  SPI**

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -72,9 +72,17 @@
 	  #elif defined SOFTSPI
 	  // change these pins to your liking
       //
-      const uint8_t SOFT_SPI_MISO_PIN = 16; 
-      const uint8_t SOFT_SPI_MOSI_PIN = 15; 
-      const uint8_t SOFT_SPI_SCK_PIN = 14;  
+      #ifndef SOFT_SPI_MISO_PIN
+      #define SOFT_SPI_MISO_PIN 9
+      #endif
+
+      #ifndef SOFT_SPI_MOSI_PIN
+      #define SOFT_SPI_MOSI_PIN 8
+      #endif
+
+      #ifndef SOFT_SPI_SCK_PIN
+      #define SOFT_SPI_SCK_PIN 7
+      #endif 
       const uint8_t SPI_MODE = 0;
       #define _SPI spi
       


### PR DESCRIPTION
This pull request is a solution for #369 

*Example project to test*

platformio.ini
```ini
[env:uno]
platform = atmelavr
board = uno
framework = arduino
lib_deps =
    https://github.com/trojanc/RF24.git#069a4f491347f3e6963da92118fb44a950a1699f
    DigitalIO@1.0.0
build_flags = -DSOFTSPI -DSOFT_SPI_SCK_PIN=9 -DSOFT_SPI_MOSI_PIN=7 -DSOFT_SPI_MISO_PIN=8
```
app.cpp
```c++
#include <Arduino.h>
#include <SPI.h>
#include "DigitalIO.h"
#include "RF24.h"
#include "printf.h"

RF24 radio(5, 6);
void setup(){
    Serial.begin(115200);
    printf_begin();

    radio.begin();
    radio.printDetails();
}

void loop(){
}
```
_also add printf.h from library to source directory_

Using this fix you can install the library and configure the soft spi pins without having to change source code of the library