### PR TITLE
Remove progmem macro overrides for ESP8266 (ESP8266 Arduino now supports them)

### DIFF
--- a/RF24_config.h
+++ b/RF24_config.h
@@ -123,14 +123,7 @@
 // Arduino DUE is arm and does not include avr/pgmspace
 #if defined (ARDUINO_ARCH_ESP8266)
 
-  #define PSTR(x) (x)
-  #define printf Serial.printf
-  #define sprintf(...) os_sprintf( __VA_ARGS__ )
-  #define printf_P printf
-  #define strlen_P strlen  
-  #define PROGMEM
-  #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
-  #define pgm_read_word(p) (*(p))
+  #include <pgmspace.h>
   #define PRIPSTR "%s"
 
 #elif defined(ARDUINO) && ! defined(__arm__) && !defined (__ARDUINO_X86__) || defined(XMEGA)


### PR DESCRIPTION
Not sure exactly when PROGMEM support was added to ESP8266 Arduino, but all of the necessary features are available:

http://esp8266.github.io/Arduino/versions/2.0.0-rc2/doc/reference.html#progmem

This PR removes the macro overrides that disable PROGMEM for ESP8266. I found that  `PRIPSTR` was still necessary.

Without this, pulling the RF24 library into an ESP8266 project clobbers the ability to use PROGMEM reliably.