### PR TITLE
Add 4 pin mode for ATTINY85 (much less power and still one pin free)

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -16,7 +16,7 @@ void RF24::csn(bool mode)
 {
 
 #if defined (RF24_TINY)
-	if (ce_pin != csn_pin) {
+	if ((ce_pin != csn_pin) && (csn_pin != 0)) {
 		digitalWrite(csn_pin,mode);
 	} 
 	else {

--- a/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
+++ b/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
@@ -36,6 +36,18 @@ version 2 as published by the Free Software Foundation.
                         |        +----+                                       |
                         |-----------------------------------------------||----x-- nRF24L01 CSN, pin4 
                                                                        10nF
+    ATtiny25/45/85 Pin map with CE_PIN 3 and CSN_PIN 0 => PB4 is free to use for application and you can use ackPayload funtionallity
+    and you will save power as RF24 could get into sleep between writings as we control CE_PIN
+    
+                                                                                            ^^
+                                 +-\/-+                                                    //
+                           PB5  1|o   |8  Vcc --- nRF24L01  VCC, pin2 -----------------x--|<|-- 5V
+    nRF24L01  CE, pin3 --- PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5 --|<|---x-[22k]--|  LED
+                   NC      PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin7  1n4148 |
+    nRF24L01 GND, pin1 -x- GND  4|    |5  PB0 --- nRF24L01 MISO, pin6         |
+                        |        +----+                                       |
+                        |-----------------------------------------------||----x-- nRF24L01 CSN, pin4 
+                                                                       10nF    
 
     ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7
 	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz)
@@ -54,6 +66,7 @@ version 2 as published by the Free Software Foundation.
 #define CE_PIN 3
 #define CSN_PIN 4
 //#define CSN_PIN 3 // uncomment for ATtiny85 3 pins solution
+//#define CSN_PIN 0 // uncomment for ATtiny85 4 pins solution
 
 #include "RF24.h"
 


### PR DESCRIPTION
Add a simple option (CSN = 0) to control RF24 with 4 pins of the ATTINY85.

This way you could use ackPayload functionallity and, more important, less power, as:

1. in 3 pin mode, CE is always HIGH so we will consuming about 12-13 mA
2. in 4 pin mode, CE is control by ATTINY so we will consuming 12-13 mA durings writes and almost nothing between them

NOTE: Sorry if I can't explain well, but I have check y modifications and they are working.