### PR TITLE
Change perror/abort in SPIDEV driver c++ std exception

### DIFF
--- a/utility/SPIDEV/RF24_arch_config.h
+++ b/utility/SPIDEV/RF24_arch_config.h
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <sys/time.h>
 
+#define RF24_SPI_SPEED RF24_SPIDEV_SPEED
+
 #define _BV(x) (1<<(x))
 #define _SPI spi
 
@@ -47,7 +49,7 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p)) 
+#define pgm_read_word(p) (*(p))
 #define PRIPSTR "%s"
 #define pgm_read_byte(p) (*(p))
 

--- a/utility/SPIDEV/spi.cpp
+++ b/utility/SPIDEV/spi.cpp
@@ -4,6 +4,8 @@
  *
  * Created on 24 June 2012, 11:00 AM
  *
+ * Patched for exception handling and selectable SPI SPEED by ldiaz 2018.
+ *
  * Inspired from spidev test in linux kernel documentation
  * www.kernel.org/doc/Documentation/spi/spidev_test.c
  */
@@ -20,10 +22,10 @@
 
 #define RF24_SPIDEV_BITS 8
 
-SPI::SPI():fd(-1) {
+SPI::SPI():fd(-1), _spi_speed(RF24_SPIDEV_SPEED) {
 }
 
-void SPI::begin(int busNo){
+void SPI::begin(int busNo,uint32_t spi_speed){
 
     /* set spidev accordingly to busNo like:
      * busNo = 23 -> /dev/spidev2.3
@@ -34,24 +36,27 @@ void SPI::begin(int busNo){
 	device[11] += (busNo / 10) % 10;
 	device[13] += busNo % 10;
 
-    if (this->fd < 0)  // check whether spi is already open
-    {
-	  this->fd = open(device, O_RDWR);
+	if(this->fd >=0) // check whether spi is already open
+	{
+		close(this->fd);
+		this->fd=-1;
+	}
 
-      if (this->fd < 0)
-      {
+	this->fd = open(device, O_RDWR);
+  if (this->fd < 0) throw SPIException("can't open device");
+	/*
+  {
         perror("can't open device");
         abort();
-      }
-    }
 
-	init();
+  }*/
+
+	init(spi_speed);
 }
 
-void SPI::init()
+void SPI::init(uint32_t speed)
 {
 	uint8_t bits = RF24_SPIDEV_BITS;
-	uint32_t speed = RF24_SPIDEV_SPEED;
 	uint8_t mode = 0;
 
 	int ret;
@@ -59,51 +64,52 @@ void SPI::init()
 	 * spi mode
 	 */
 	ret = ioctl(this->fd, SPI_IOC_WR_MODE, &mode);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("cant set WR spi mode");
+	/*{
 		perror("can't set spi mode");
 		abort();
-	}
+	}*/
 
 	ret = ioctl(this->fd, SPI_IOC_RD_MODE, &mode);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("can't set RD spi mode");
+	/*{
 		perror("can't set spi mode");
 		abort();
-	}
+	}*/
 
 	/*
 	 * bits per word
 	 */
 	ret = ioctl(this->fd, SPI_IOC_WR_BITS_PER_WORD, &bits);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("can't set WR bits per word");
+	/*{
 		perror("can't set bits per word");
 		abort();
-	}
+	}*/
 
 	ret = ioctl(this->fd, SPI_IOC_RD_BITS_PER_WORD, &bits);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("can't set RD bits per word");
+	/*{
 		perror("can't set bits per word");
 		abort();
-	}
+	}*/
 	/*
 	 * max speed hz
 	 */
 	ret = ioctl(this->fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("can't WR set max speed hz");
+	/*{
 		perror("can't set max speed hz");
 		abort();
-	}
+	}*/
 
 	ret = ioctl(this->fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed);
-	if (ret == -1)
-	{
+	if (ret == -1) throw SPIException("can't RD set max speed hz");
+	/*{
 		perror("can't set max speed hz");
 		abort();
-	}
+	}*/
+	_spi_speed=speed;
 }
 
 uint8_t SPI::transfer(uint8_t tx)
@@ -114,18 +120,18 @@ uint8_t SPI::transfer(uint8_t tx)
 	uint8_t rx;
 	tr.rx_buf = (unsigned long)&rx;
 	tr.len = sizeof(tx);
-	tr.speed_hz = RF24_SPIDEV_SPEED;
+	tr.speed_hz = _spi_speed; //RF24_SPIDEV_SPEED;
 	tr.delay_usecs = 0;
 	tr.bits_per_word = RF24_SPIDEV_BITS;
 	tr.cs_change = 0;
 
 	int ret;
 	ret = ioctl(this->fd, SPI_IOC_MESSAGE(1), &tr);
-	if (ret < 1)
-	{
+	if (ret < 1) throw SPIException("can't send spi message");
+	/*{
 		perror("can't send spi message");
 		abort();
-	}
+	}*/
 
 	return rx;
 }
@@ -137,21 +143,20 @@ void SPI::transfernb(char* tbuf, char* rbuf, uint32_t len)
     tr.tx_buf = (unsigned long)tbuf;
     tr.rx_buf = (unsigned long)rbuf;
     tr.len = len;
-    tr.speed_hz = RF24_SPIDEV_SPEED;
+    tr.speed_hz = _spi_speed; //RF24_SPIDEV_SPEED;
     tr.delay_usecs = 0;
     tr.bits_per_word = RF24_SPIDEV_BITS;
     tr.cs_change = 0;
 
 	int ret;
 	ret = ioctl(this->fd, SPI_IOC_MESSAGE(1), &tr);
-	if (ret < 1)
-	{
+	if (ret < 1) throw SPIException("can't send spi message");
+	/*{
 		perror("can't send spi message");
 		abort();
-	}
+	}*/
 }
 
 SPI::~SPI() {
-	if (!(this->fd < 0))
-		close(this->fd);
+	if (this->fd >= 0) close(this->fd);
 }

--- a/utility/SPIDEV/spi.h
+++ b/utility/SPIDEV/spi.h
@@ -24,13 +24,22 @@
  */
 
 #include <inttypes.h>
+#include <stdexcept>
 
 #ifndef RF24_SPIDEV_SPEED
 /* 8MHz as default */
 #define RF24_SPIDEV_SPEED 8000000
 #endif
 
+/** Specific excpetion for SPI errors */
+class SPIException : public std::runtime_error {
+	public:
+		explicit SPIException(const std::string& msg) :  std::runtime_error(msg) { }
+};
+
+
 class SPI {
+
 public:
 
 	/**
@@ -41,7 +50,7 @@ public:
 	/**
 	* Start SPI
 	*/
-	void begin(int busNo);
+	void begin(int busNo,uint32_t spi_speed=RF24_SPIDEV_SPEED);
 
 	/**
 	* Transfer a single byte
@@ -72,8 +81,9 @@ public:
 private:
 
 	int fd;
+	uint32_t _spi_speed;
 
-	void init();
+	void init(uint32_t spi_speed=RF24_SPIDEV_SPEED);
 };
 
 /**
@@ -81,4 +91,3 @@ private:
  */
 /*@}*/
 #endif	/* SPI_H */
-


### PR DESCRIPTION
Remove perror+abort (error handling) in SPIDEV driver. This solve the
problem of abort called in the library that will be terminate the
process.
a try{…} catch(SPIException &e) {} will permit consistent error
handling for library users.

This will address the following suggestion in #407 :

> Abuse of perror + abort(): Abort will stop the running process, this is not good practice for a library. A library should report the error to running process so it can be handled. As the library is C++ perror+abort should be subtitured by custom exception that can be cached by library user.