### PR TITLE
Fixed misleading indent warning in bcm2835.c

### DIFF
--- a/utility/RPi/bcm2835.c
+++ b/utility/RPi/bcm2835.c
@@ -420,8 +420,8 @@ uint32_t bcm2835_gpio_pad(uint8_t group)
   if (bcm2835_pads == MAP_FAILED)
     return 0;
   
-    volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
-    return bcm2835_peri_read(paddr);
+  volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
+  return bcm2835_peri_read(paddr);
 }
 
 /* Set GPIO pad behaviour for groups of GPIOs
@@ -433,8 +433,8 @@ void bcm2835_gpio_set_pad(uint8_t group, uint32_t control)
   if (bcm2835_pads == MAP_FAILED)
     return;
   
-    volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
-    bcm2835_peri_write(paddr, control | BCM2835_PAD_PASSWRD);
+  volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
+  bcm2835_peri_write(paddr, control | BCM2835_PAD_PASSWRD);
 }
 
 /* Some convenient arduino-like functions


### PR DESCRIPTION
Previously when compiling with the bcm2835/RPi driver gcc would emit the following warnings:

    utility/RPi/bcm2835.c: In function ‘bcm2835_gpio_pad’:
    utility/RPi/bcm2835.c:420:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
    if (bcm2835_pads == MAP_FAILED)
    ^~
    utility/RPi/bcm2835.c:423:5: note: ...this statement, but the latter is misleadingly indented as if it is 
    guarded by the ‘if’
    volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
    ^~~~~~~~
    utility/RPi/bcm2835.c: In function ‘bcm2835_gpio_set_pad’:
    utility/RPi/bcm2835.c:433:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
    if (bcm2835_pads == MAP_FAILED)
    ^~
    utility/RPi/bcm2835.c:436:5: note: ...this statement, but the latter is misleadingly indented as if it is 
    guarded by the ‘if’
    volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;

This was caused by a simple misplaced indent in the two functions mentioned. These indents were removed and the compiler no longer emits these warnings.