### PR TITLE
SPIDEV compatibility layer improvement and patch for 64bits

### DIFF
--- a/utility/SPIDEV/compatibility.c
+++ b/utility/SPIDEV/compatibility.c
@@ -2,8 +2,9 @@
 #include "compatibility.h"
 
 
-static long mtime, seconds, useconds;
-static struct timeval start, end;
+static uint32_t mtime, seconds, useconds;
+//static struct timeval start, end;
+struct timespec start, end;
 
 /**********************************************************************/
 /**
@@ -12,18 +13,20 @@ static struct timeval start, end;
  */
 void __msleep(int milisec)
 {
-	struct timespec req = {0};
-	req.tv_sec = 0;
-	req.tv_nsec = milisec * 1000000L;
-	nanosleep(&req, (struct timespec *)NULL);	
+	struct timespec req;// = {0};
+	req.tv_sec = (time_t) milisec / 1000;
+	req.tv_nsec = (milisec % 1000 ) * 1000000L;
+	//nanosleep(&req, (struct timespec *)NULL);	
+	clock_nanosleep(CLOCK_MONOTONIC_RAW, 0, &req, NULL);
 }
 
-void __usleep(int milisec)
+void __usleep(int microsec)
 {
-	struct timespec req = {0};
-	req.tv_sec = 0;
-	req.tv_nsec = milisec * 1000L;
-	nanosleep(&req, (struct timespec *)NULL);	
+	struct timespec req;// = {0};
+	req.tv_sec = (time_t) microsec/ 1000000;
+	req.tv_nsec = (microsec / 1000000) * 1000;
+	//nanosleep(&req, (struct timespec *)NULL);
+	clock_nanosleep(CLOCK_MONOTONIC_RAW, 0, &req, NULL);	
 }
 
 /**
@@ -33,14 +36,16 @@ void __usleep(int milisec)
  
 void __start_timer()
 {
-	gettimeofday(&start, NULL);
+	//gettimeofday(&start, NULL);
+	clock_gettime(CLOCK_MONOTONIC, &start);
 }
 
-long __millis()
+uint32_t __millis()
 {
-	gettimeofday(&end, NULL);
+	//gettimeofday(&end, NULL);
+	clock_gettime(CLOCK_MONOTONIC,&end);
     seconds  = end.tv_sec  - start.tv_sec;
-    useconds = end.tv_usec - start.tv_usec;
+    useconds = (end.tv_nsec - start.tv_nsec)/1000;
 
     mtime = ((seconds) * 1000 + useconds/1000.0) + 0.5;	
 	return mtime;

--- a/utility/SPIDEV/compatibility.h
+++ b/utility/SPIDEV/compatibility.h
@@ -3,6 +3,7 @@
  * Author: purinda
  *
  * Created on 24 June 2012, 3:08 PM
+ * patch for safer monotonic clock & millis() correction for 64bit LDV 2018
  */
 
 #ifndef COMPATIBLITY_H
@@ -11,7 +12,8 @@
 #ifdef	__cplusplus
 extern "C" {
 #endif
-	
+
+#include <stdint.h>  // for uintXX_t types	
 #include <stddef.h>
 #include <time.h>
 #include <sys/time.h>
@@ -19,7 +21,7 @@ extern "C" {
 void __msleep(int milisec);
 void __usleep(int milisec);
 void __start_timer();
-long __millis();
+uint32_t __millis();
 
 #ifdef	__cplusplus
 }

--- a/utility/SPIDEV/gpio.cpp
+++ b/utility/SPIDEV/gpio.cpp
@@ -1,17 +1,23 @@
-/* 
+/*
  * https://github.com/mrshu/GPIOlib
  * Copyright (c) 2011, Copyright (c) 2011 mr.Shu
- * All rights reserved. 
- * 
+ * All rights reserved.
+ *
  * Modified on 24 June 2012, 11:06 AM
  * File:   gpio.cpp
  * Author: purinda (purinda@gmail.com)
- * 
+ *
+ *  Patched for filedescriptor catching and error control by L Diaz 2018
  */
 
 #include "gpio.h"
 #include <stdlib.h>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+std::map<int,GPIOfdCache_t> GPIO::cache;
 
 GPIO::GPIO() {
 }
@@ -23,41 +29,84 @@ void GPIO::open(int port, int DDR)
 {
 	FILE *f;
 	f = fopen("/sys/class/gpio/export", "w");
+	if(f==NULL) throw GPIOException("can't export GPIO pin .check access rights");
 	fprintf(f, "%d\n", port);
 	fclose(f);
 
-    int counter = 0;
-	char file[128];    
-	sprintf(file, "/sys/class/gpio/gpio%d/direction", port);  
-    
+  int counter = 0;
+	char file[128];
+	sprintf(file, "/sys/class/gpio/gpio%d/direction", port);
+
     while( ( f = fopen(file,"w")) == NULL ){ //Wait 10 seconds for the file to be accessible if not open on first attempt
         sleep(1);
         counter++;
         if(counter > 10){
-          perror("Could not open /sys/class/gpio/gpio%d/direction");
-          exit(0);
+					throw GPIOException("can't access /sys/class/gpio/gpio%d/direction GPIO pin. check access rights");
+          /*perror("Could not open /sys/class/gpio/gpio%d/direction");
+          exit(0); */
         }
     }
+	int l=(DDR==0) ? fprintf(f, "in\n") : fprintf(f, "out\n");
+	if(!(l==3 || l==4)) {
+		fclose(f);
+		throw GPIOException("can't set direction on GPIO pin. check access rights");
+	}
+	/*
 	if (DDR == 0)
           fprintf(f, "in\n");
-	else  fprintf(f, "out\n");
-    
-    fclose(f);
+	else  printf(f, "out\n");
+  */
+  fclose(f);
+
+	// Caches the GPIO descriptor;
+	sprintf(file, "/sys/class/gpio/gpio%d/value", port);
+	int flags= (DDR==0) ? O_RDONLY : O_WRONLY;
+	int fd=::open(file,flags);
+	if(fd<0) {
+		throw GPIOException("Can't open the GPIO");
+	} else {
+		cache[port]=fd;  // cache the fd;
+		lseek(fd,SEEK_SET,0);
+	}
 
 }
 
 void GPIO::close(int port)
 {
+  std::map<int,GPIOfdCache_t>::iterator i;
+	i=cache.find(port);
+	if(i!=cache.end()){
+		close(i->second); // close the cached fd
+		cache.erase(i); // Delete cache entry
+	}
+	// Do unexport
 	FILE *f;
 	f = fopen("/sys/class/gpio/unexport", "w");
-	fprintf(f, "%d\n", port);
-	fclose(f);
+	if(f!=NULL) {
+		fprintf(f, "%d\n", port);
+	  fclose(f);
+	}
 }
 
 int GPIO::read(int port)
 {
-	FILE *f;
-	
+  std::map<int,GPIOfdCache_t>::iterator i;
+  int fd;
+	i=cache.find(port);
+	if(i==cache.end()){ // Fallback to open the gpio
+		GPIO::open(port,GPIO::DIRECTION_IN);
+		i=cache.find(port);
+		if(i==cache.end()) throw GPIOException("can't access to GPIO");
+		else fd=i->second;
+	} else fd=i->second;
+
+	char c;
+	if(lseek(fd,0,SEEK_SET)==0 && ::read(fd,&c,1)==1){
+		return (c=='0') ? 0 : 1;
+	} else throw GPIOException("can't access to GPIO");
+
+	/*FILE *f;
+
 	char file[128];
 	sprintf(file, "/sys/class/gpio/gpio%d/value", port);
 	f = fopen(file, "r");
@@ -66,17 +115,31 @@ int GPIO::read(int port)
 	fscanf(f, "%d", &i);
 	fclose(f);
 	return i;
-
+*/
 }
 void GPIO::write(int port, int value){
-	FILE *f;
+	std::map<int,GPIOfdCache_t>::iterator i;
+  int fd;
+	i=cache.find(port);
+	if(i==cache.end()){ // Fallback to open the gpio
+		GPIO::open(port,GPIO::DIRECTION_OUT);
+		i=cache.find(port);
+		if(i==cache.end()) throw GPIOException("can't access to GPIO");
+		else fd=i->second;
+	} else fd=i->second;
+
+	if(lseek(fd,0,SEEK_SET)!=0) throw GPIOException("can't access to GPIO");
+	int l=(value==0) ? ::write(fd,"0\n",2) : ::write(fd,"1\n",2);
+	if(l!=2) throw GPIOException("can't access to GPIO");
+
+	/*FILE *f;
 
 	char file[128];
 	sprintf(file, "/sys/class/gpio/gpio%d/value", port);
 	f = fopen(file, "w");
-	
+
 	if (value == 0)	fprintf(f, "0\n");
 	else		fprintf(f, "1\n");
-	
-	fclose(f);
+
+	fclose(f);*/
 }

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -1,26 +1,34 @@
-/* 
+/*
  * https://github.com/mrshu/GPIOlib
  * Copyright (c) 2011, Copyright (c) 2011 mr.Shu
- * All rights reserved. 
- * 
+ * All rights reserved.
+ *
  * Modified on 24 June 2012, 11:06 AM
  * File:   gpio.h
  * Author: purinda (purinda@gmail.com)
- * 
+ *
  */
 
 #ifndef H
 #define	H
 
 #include <cstdio>
+#include <map>
+#include <stdexcept>
+
+/** Specific excpetion for SPI errors */
+class GPIOException : public std::runtime_error {
+	public:
+		explicit GPIOException(const std::string& msg) :  std::runtime_error(msg) { }
+};
 
 /**
  * @file gpio.h
  * \cond HIDDEN_SYMBOLS
  * Class declaration for GPIO helper files
  */
- 
- 
+
+
 /**
  * Example GPIO.h file
  *
@@ -29,7 +37,8 @@
  * See RF24_arch_config.h for additional information
  * @{
  */
- 
+
+typedef int GPIOfdCache_t;
 
 class GPIO {
 public:
@@ -37,12 +46,12 @@ public:
 	/* Constants */
 	static const int DIRECTION_OUT = 1;
 	static const int DIRECTION_IN = 0;
-	
+
 	static const int OUTPUT_HIGH = 1;
 	static const int OUTPUT_LOW = 0;
-		
+
 	GPIO();
-	
+
 	/**
 	 * Similar to Arduino pinMode(pin,mode);
      * @param port
@@ -50,7 +59,7 @@ public:
      */
 	static void open(int port, int DDR);
 	/**
-	 * 
+	 *
      * @param port
      */
 	static void close(int port);
@@ -64,17 +73,17 @@ public:
 	* Similar to Arduino digitalWrite(pin,state);
 	* @param port
 	* @param value
-	*/	
-	static void write(int port,int value);	
-	
-	virtual ~GPIO();
-	
-private:
+	*/
+	static void write(int port,int value);
 
+	virtual ~GPIO();
+
+private:
+  /* fd cache */
+  static std::map<int,GPIOfdCache_t> cache;
 };
 /**
  * \endcond
  */
 /*@}*/
 #endif	/* H */
-


### PR DESCRIPTION
Improve the SPIDEV compatibility layer:

- Solve #454 that breaks millis() functions.
- Improve delay,delayMicros & millis() using clock_* functions vs nanosleep/getimeofday that are considered deprecated or not safe.
- Address issue #407 for GPIO error management avoiding exit/abort calling in favor of specific exception that can be controlled by the calling program.
- Improve GPIO speed caching sysfs files and using system calls to reduce FILE* overhead. GPIO switching will be faster.

This PR has been tested in 32bit & 64bit envirments
