### PR TITLE
Automatically choose correct SPI clock divider.

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -41,7 +41,24 @@ void RF24::csn(bool mode)
       #if !defined (SOFTSPI)	
 		_SPI.setBitOrder(MSBFIRST);
 		_SPI.setDataMode(SPI_MODE0);
-		_SPI.setClockDivider(SPI_CLOCK_DIV2);
+		#if !defined(F_CPU) || F_CPU < 20000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV2);
+		#elif F_CPU < 40000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV4);
+		#elif F_CPU < 80000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV8);
+		#elif F_CPU < 160000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV16);
+		#elif F_CPU < 320000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV32);
+		#elif F_CPU < 640000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV64);
+		#elif F_CPU < 1280000000
+			_SPI.setClockDivider(SPI_CLOCK_DIV128);
+		#else
+			#error "Unsupported CPU frequency. Please set correct SPI divider."
+		#endif
+
       #endif
 #elif defined (RF24_RPi)
       if(!mode)


### PR DESCRIPTION
Before this change the divider is always 2 which violates the
nRF24L01 timing requirements for clock frequencies > 20MHz.
Now a suitable divider is chosen automatically to keep the
SPI clock frequency in the range 5 MHz - 10MHz.

This change is required for STM32F103 boards which run at 72MHz by default. Everything else works out of the box => closes #462.