### PR TITLE
ATtiny84 comment improvements for #491

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1599,11 +1599,17 @@ void RF24::setRetries(uint8_t delay, uint8_t count)
 #	define SS   3  // D3, pin 2  Slave Select
 #elif defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 // these depend on the core used (check pins_arduino.h)
-// this is for jeelabs' one (based on google-code core)
+// tested with google-code core
 #	define DI   4   // PA6
 #	define DO   5   // PA5
 #	define USCK 6   // PA4
 #	define SS   3   // PA7
+// tested with spencekonde core (https://github.com/SpenceKonde/ATTinyCore)
+// and mit high-low tech core (https://github.com/damellis/attiny)
+// #	define DI   6   // PA6 - USI Data Input  - Radio MISO
+// #	define DO   5   // PA5 - USI Data Output - Radio MOSI
+// #	define USCK 4   // PA4 - USI Clock       - Radio SCK
+// #	define SS   3   // (not used by USI, user configured in RF24 constructor)
 #elif defined(__AVR_ATtiny2313__) || defined(__AVR_ATtiny4313__)
 // these depend on the core used (check pins_arduino.h)
 // tested with google-code core

--- a/RF24.h
+++ b/RF24.h
@@ -1585,15 +1585,15 @@ private:
  *    **ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7** <br>
  *	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz) <br>
  * @code
- *                                  +-\/-+                                                              
- *    nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
- *                            PB0  2|    |13 AREF
- *                            PB1  3|    |12 PA1
- *                            PB3  4|    |11 PA2 --- nRF24L01   CE, pin3
- *                            PB2  5|    |10 PA3 --- nRF24L01  CSN, pin4
- *                            PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5
- *    nRF24L01 MISO, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MOSI, pin6
- *                                  +----+
+ *                                        +-\/-+                                                              
+ *          nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
+ *                                  PB0  2|    |13 AREF
+ *                                  PB1  3|    |12 PA1
+ *                                  PB3  4|    |11 PA2 --- nRF24L01   CE, pin3
+ *                                  PB2  5|    |10 PA3 --- nRF24L01  CSN, pin4
+ *                                  PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5 (USI CK) 
+ * (USI DI) nRF24L01 MISO, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MOSI, pin6 (USI DO)
+ *                                        +----+
  *	@endcode					 
  *	
  * <br>

--- a/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
+++ b/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
@@ -3,6 +3,8 @@ This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 version 2 as published by the Free Software Foundation.
 
+    Verify DI, DO, and USCK defines in RF24.cpp are correct for your ATtiny core.
+
     rf24ping85.ino by tong67 ( https://github.com/tong67 )
     This is an example of how to use the RF24 class to communicate with ATtiny85 and other node.
     Write this sketch to an ATtiny85. It will act like the 'transmit' mode of GettingStarted.ino
@@ -37,7 +39,7 @@ version 2 as published by the Free Software Foundation.
                         |-----------------------------------------------||----x-- nRF24L01 CSN, pin4 
                                                                        10nF
 
-    ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7
+    ATtiny24/44/84 Pin map
 	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz)
                                        +-\/-+
          nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1

--- a/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
+++ b/examples/rf24_ATTiny/rf24ping85/rf24ping85.ino
@@ -39,15 +39,15 @@ version 2 as published by the Free Software Foundation.
 
     ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7
 	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz)
-                                  +-\/-+
-    nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
-                            PB0  2|    |13 AREF
-                            PB1  3|    |12 PA1
-                            PB3  4|    |11 PA2 --- nRF24L01   CE, pin3
-                            PB2  5|    |10 PA3 --- nRF24L01  CSN, pin4
-                            PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5
-    nRF24L01 MOSI, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MISO, pin6
-                                  +----+
+                                       +-\/-+
+         nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
+                                 PB0  2|    |13 AREF
+                                 PB1  3|    |12 PA1
+                                 PB3  4|    |11 PA2 --- nRF24L01   CE, pin3
+                                 PB2  5|    |10 PA3 --- nRF24L01  CSN, pin4
+                                 PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5 (USI CK)
+(USI DI) nRF24L01 MISO, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MOSI, pin6 (USI DO)
+                                       +----+
 */
 
 // CE and CSN are configurable, specified values for ATtiny85 as connected above

--- a/examples/rf24_ATTiny/timingSearch3pin/timingSearch3pin.ino
+++ b/examples/rf24_ATTiny/timingSearch3pin/timingSearch3pin.ino
@@ -126,11 +126,17 @@ version 2 as published by the Free Software Foundation.
 #	define SS   3  // D3, pin 2  Slave Select
 #elif defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 // these depend on the core used (check pins_arduino.h)
-// this is for jeelabs' one (based on google-code core)
+// tested with google-code core
 #	define DI   4   // PA6
 #	define DO   5   // PA5
 #	define USCK 6   // PA4
 #	define SS   3   // PA7
+// tested with spencekonde core (https://github.com/SpenceKonde/ATTinyCore)
+// and mit high-low tech core (https://github.com/damellis/attiny)
+// #	define DI   6   // PA6 - USI Data Input  - Radio MISO
+// #	define DO   5   // PA5 - USI Data Output - Radio MOSI
+// #	define USCK 4   // PA4 - USI Clock       - Radio SCK
+// #	define SS   3   // (not used by USI, user configured in RF24 constructor)
 #endif
 
 #if defined (ARDUINO) && !defined (__arm__)


### PR DESCRIPTION
This PR adds clarity when using the ATtiny84,  Unfortunately the ATtiny84's MISO and MOSI pins used for the ICSP interface do not align with the nRF24L01 MISO and MOSI pins.  This is due to the ATtiny84 using its USI peripheral to communicate with the radio.  The USI DI pin must connect to the radio's MISO pin, however, the USI DI pin happens to be the ICSP MOSI pin, so there is much confusion.

```
                                               +-\/-+                                                              
                                         VCC  1|o   |14 GND
                                         PB0  2|    |13 AREF
                                         PB1  3|    |12 PA1
                                         PB3  4|    |11 PA2
                                         PB2  5|    |10 PA3
                                         PA7  6|    |9  PA4 --- ICSP SCK  / USI SCK --- nRF24L01 SCK
nRF24L01 MISO --- USI DI / ICSP MOSI --- PA6  7|    |8  PA5 --- ICSP MISO / USI DO  --- nRF24L01 MOSI
                                               +----+
```

In addition, there several popular ATtiny board libraries that have incompatible pin mappings.  So the mappings for these additional ATtiny boards have been added to the comments.