### PR TITLE
Avoid some compiler warnings

### DIFF
--- a/examples/Transfer/Transfer.ino
+++ b/examples/Transfer/Transfer.ino
@@ -1,15 +1,17 @@
 /*
-TMRh20 2014
+ TMRh20 2014
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
  */
 
-/** General Data Transfer Rate Test
- * This example demonstrates basic data transfer functionality with the 
- updated library. This example will display the transfer rates acheived using
- the slower form of high-speed transfer using blocking-writes.
+/*
+ General Data Transfer Rate Test
+ 
+ This example demonstrates basic data transfer functionality with the 
+ updated library. This example will display the transfer rates acheived 
+ using the slower form of high-speed transfer using blocking-writes.
  */
 
 
@@ -17,16 +19,16 @@ TMRh20 2014
 #include "RF24.h"
 
 /*************  USER Configuration *****************************/
-                                          // Hardware configuration
-RF24 radio(7,8);                        // Set up nRF24L01 radio on SPI bus plus pins 7 & 8
+                                           // Hardware configuration
+RF24 radio(7,8);                           // Set up nRF24L01 radio on SPI bus plus pins 7 & 8
 
 /***************************************************************/
 
 const uint64_t pipes[2] = { 0xABCDABCD71LL, 0x544d52687CLL };   // Radio pipe addresses for the 2 nodes to communicate.
 
-byte data[32];                           //Data buffer for testing data transfer speeds
+byte data[32];                             //Data buffer for testing data transfer speeds
 
-unsigned long counter, rxTimer;          //Counter and timer for keeping track transfer info
+unsigned long counter, rxTimer;            //Counter and timer for keeping track transfer info
 unsigned long startTime, stopTime;  
 bool TX=1,RX=0,role=0;
 
@@ -36,7 +38,7 @@ void setup(void) {
 
   radio.begin();                           // Setup and configure rf radio
   radio.setChannel(1);
-  radio.setPALevel(RF24_PA_MAX);           //if you wanna save power and you do not need the whole range, just use "RF24_PA_MIN"
+  radio.setPALevel(RF24_PA_MAX);           // If you want to save power use "RF24_PA_MIN" but keep in mind that reduces the module's range
   radio.setDataRate(RF24_1MBPS);
   radio.setAutoAck(1);                     // Ensure autoACK is enabled
   radio.setRetries(2,15);                  // Optionally, increase the delay between retries & # of retries
@@ -45,25 +47,24 @@ void setup(void) {
   radio.openWritingPipe(pipes[0]);
   radio.openReadingPipe(1,pipes[1]);
   
-  radio.startListening();                 // Start listening
-  radio.printDetails();                   // Dump the configuration of the rf unit for debugging
+  radio.startListening();                  // Start listening
+  radio.printDetails();                    // Dump the configuration of the rf unit for debugging
   
   Serial.println(F("\n\rRF24/examples/Transfer/"));
   Serial.println(F("*** PRESS 'T' to begin transmitting to the other node"));
   
-  randomSeed(analogRead(0));              //Seed for random number generation
+  randomSeed(analogRead(0));               //Seed for random number generation
   
-  for(int i=0; i<32; i++){
-     data[i] = random(255);               //Load the buffer with random data
+  for(int i = 0; i < 32; i++){
+     data[i] = random(255);                //Load the buffer with random data
   }
-  radio.powerUp();                        //Power up the radio
+  radio.powerUp();                         //Power up the radio
 }
 
 void loop(void){
 
 
   if(role == TX){
-    
     delay(2000);
     
     Serial.println(F("Initiating Basic Data Transfer"));

--- a/utility/RPi/bcm2835.c
+++ b/utility/RPi/bcm2835.c
@@ -488,9 +488,9 @@ void bcm2835_gpio_pudclk(uint8_t pin, uint8_t on)
 /* Read GPIO pad behaviour for groups of GPIOs */
 uint32_t bcm2835_gpio_pad(uint8_t group)
 {
-  if (bcm2835_pads == MAP_FAILED)
-    return 0;
-  
+    if (bcm2835_pads == MAP_FAILED) {
+        return 0;
+    } 
     volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
     return bcm2835_peri_read(paddr);
 }
@@ -501,9 +501,9 @@ uint32_t bcm2835_gpio_pad(uint8_t group)
 */
 void bcm2835_gpio_set_pad(uint8_t group, uint32_t control)
 {
-  if (bcm2835_pads == MAP_FAILED)
-    return;
-  
+    if (bcm2835_pads == MAP_FAILED) {
+        return;
+    } 
     volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
     bcm2835_peri_write(paddr, control | BCM2835_PAD_PASSWRD);
 }


### PR DESCRIPTION
With the original code i got 2 compiler warnings when i compile on raspbian buster. 2 brackets each solve this.
Warnings:
utility/RPi/bcm2835.c:491:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if (bcm2835_pads == MAP_FAILED)
   ^~
utility/RPi/bcm2835.c:494:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
     volatile uint32_t* paddr = bcm2835_pads + BCM2835_PADS_GPIO_0_27/4 + group;
     ^~~~~~~~
