### PR TITLE
Fix ESP32 SPI speed issues

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -10,6 +10,11 @@
 #include "RF24_config.h"
 #include "RF24.h"
 
+// For some reason, the ESP32 compiler refuses to define this correctly in RF24_config.h, so we have to brute force it here
+#ifdef HAL_ESP32_HAL_H_
+#define RF24_SPI_TRANSACTIONS
+#endif
+
 /****************************************************************************/
 
 void RF24::csn(bool mode)


### PR DESCRIPTION
Without SPI transactions enabled, the SPI speed is set to CPU_F/128 and accessing shared devices on the SPI bus (TFT display in my case), also run at the slow speed even if transactions are used. Explicitly setting the SPI clock seems to disable the ability of transactions to affect the clock speed later. I tried fixing this in RF24_config.h, but the compiler is behaving oddly and won't properly define RF24_SPI_TRANSACTIONS, so the only way I got it to work was to place it in RF24.cpp.