### PR TITLE
Fix #ifdef used with define(RF24_RPi)

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -605,7 +605,7 @@ bool RF24::begin(void)
     gpio.begin(ce_pin,csn_pin);
         #endif
 
-        #ifdef defined(RF24_RPi)
+        #if defined(RF24_RPi)
     switch(csn_pin){     //Ensure valid hardware CS pin
       case 0: break;
       case 1: break;

--- a/utility/RPi/spi.cpp
+++ b/utility/RPi/spi.cpp
@@ -1,6 +1,7 @@
 #include "spi.h"
 #include <pthread.h>
 #include <unistd.h>
+#include <stdexcept>
 
 static pthread_mutex_t spiMutex = PTHREAD_MUTEX_INITIALIZER;
 bool bcmIsInitialized = false;
@@ -24,7 +25,7 @@ void SPI::begin(int busNo)
 void SPI::beginTransaction(SPISettings settings)
 {
     if (geteuid() != 0) {
-        throw -1;
+        throw std::runtime_error("Process should run as root");
     }
     pthread_mutex_lock(&spiMutex);
     setBitOrder(settings.border);


### PR DESCRIPTION
That resulted in the init code for Raspberry Pi to
not be executed.

That was introduced in the code cleanup ( 0d36fca8 ).