### PR TITLE
[RPi] Improve exception when not running as root

### DIFF
--- a/utility/RPi/spi.cpp
+++ b/utility/RPi/spi.cpp
@@ -1,6 +1,7 @@
 #include "spi.h"
 #include <pthread.h>
 #include <unistd.h>
+#include <stdexcept>
 
 static pthread_mutex_t spiMutex = PTHREAD_MUTEX_INITIALIZER;
 bool bcmIsInitialized = false;
@@ -24,7 +25,7 @@ void SPI::begin(int busNo)
 void SPI::beginTransaction(SPISettings settings)
 {
     if (geteuid() != 0) {
-        throw -1;
+        throw std::runtime_error("Process should run as root");
     }
     pthread_mutex_lock(&spiMutex);
     setBitOrder(settings.border);


### PR DESCRIPTION
It appears that on Raspberry Pi, the code checks
that the process is running as root.

When it's not, it throws a very cryptic error (see #531):
  terminate called after throwing an instance of 'int'

I'm not sure that making it compulsory to run as root
is justified, but at least this change improves the
error message.

After it appears as:
  terminate called after throwing an instance of 'std::runtime_error'
    what():  Process should run as root