### PR TITLE
Update -march definition on RPi (BCM2835)

### DIFF
--- a/configure
+++ b/configure
@@ -148,7 +148,7 @@ function gcc_cpu_flags {
     local soc=$1
     case $soc in
     BCM2835)
-        flags="-march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
+        flags="-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"
         ;;
     BCM2836)
         flags="-march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard"


### PR DESCRIPTION
Cross-compiling using arm-linux-gnueabihf-gcc 7.4.0 resulted in the following error:
```
sorry, unimplemented: Thumb-1 hard-float VFP ABI
```

It seems that using `-march=armv6` or `-march=armv6zk` with armhf results in
this error, while it works fine with `-marm` .