### PR TITLE
Add GitHub actions configuration

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -3,7 +3,7 @@ name: C/C++ CI
 on: [push]
 
 jobs:
-  build-RPi:
+  build-RPi-BCM2835:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,25 @@ jobs:
       - name: make
         run: sudo make install
 
-  build-wiringPi:
+  build-RPi-BCM2836:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: provide toolchain
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf &&
+          arm-linux-gnueabihf-gcc -v &&
+          arm-linux-gnueabihf-g++ -v
+      - name: configure
+        run: ./configure --soc=BCM2836 --driver=RPi
+      - name: make
+        run: make
+      - name: make
+        run: sudo make install
+
+  build-wiringPi-BCM2835:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,46 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build-RPi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: provide toolchain
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf &&
+          arm-linux-gnueabihf-gcc -v &&
+          arm-linux-gnueabihf-g++ -v
+      - name: configure
+        run: ./configure --soc=BCM2835 --driver=RPi
+      - name: make
+        run: make
+      - name: make
+        run: sudo make install
+
+  build-wiringPi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: provide toolchain
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf &&
+          arm-linux-gnueabihf-gcc -v &&
+          arm-linux-gnueabihf-g++ -v
+      - name: provide wiringPi
+        run: |
+          git clone https://github.com/CoRfr/WiringPi &&
+          cd WiringPi/wiringPi &&
+          CC="arm-linux-gnueabihf-gcc -marm -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" V=1 make -j5 &&
+          sudo make install
+      - name: configure
+        run: ./configure --soc=BCM2835 --driver=wiringPi --extra-cflags=-I/usr/local/include
+      - name: make
+        run: make
+      - name: make
+        run: sudo make install


### PR DESCRIPTION
This configures GitHub Actions to build for:
- BCM2835 (w/ drivers RPi and wiringPi)
- BCM2836 (w/ driver RPi)

I had to hopefully temporarily rely on a personal fork of https://github.com/WiringPi/WiringPi to make it cross-compilable. At the moment it doesn't allow CC to be externally defined, and it is set to `gcc`, so it's not possible to build from x86-64 to armhf for instance.

It should be relatively easy to add builds for other Linux platforms, and possibly Arduino too.