### PR TITLE
Fix for creating multiple instances with SPIDEV

### DIFF
--- a/utility/SPIDEV/spi.cpp
+++ b/utility/SPIDEV/spi.cpp
@@ -27,12 +27,11 @@ SPI::SPI()
 {
 }
 
-bool spiIsInitialized = 0;
 
 void SPI::begin(int busNo, uint32_t spi_speed)
 {
 
-    if (spiIsInitialized) {
+    if (this->spiIsInitialized) {
         return;
     }
 
@@ -61,7 +60,7 @@ void SPI::begin(int busNo, uint32_t spi_speed)
         abort();
 
   }*/
-    spiIsInitialized = true;
+    this->spiIsInitialized = true;
     init(spi_speed);
 }
 

--- a/utility/SPIDEV/spi.h
+++ b/utility/SPIDEV/spi.h
@@ -85,7 +85,7 @@ private:
 
     int fd;
     uint32_t _spi_speed;
-
+    bool spiIsInitialized = false;
     void init(uint32_t spi_speed = RF24_SPIDEV_SPEED);
 };
 


### PR DESCRIPTION
When creating multiple instances of SPI class using SPIDEV driver,
only the first one got initated, because spiIsInitiated was defined as
global variable. It was changed to be a private variable of SPI class.