### PR TITLE
Fixed undefined behavior on openReadingPipe

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1225,7 +1225,7 @@ void RF24::openReadingPipe(uint8_t child, uint64_t address)
         memcpy(pipe0_reading_address, &address, addr_width);
     }
 
-    if (child <= 6) {
+    if (child <= 5) {
         // For pipes 2-5, only write the LSB
         if (child < 2) {
             write_register(pgm_read_byte(&child_pipe[child]), reinterpret_cast<const uint8_t*>(&address), addr_width);
@@ -1266,7 +1266,7 @@ void RF24::openReadingPipe(uint8_t child, const uint8_t* address)
     if (child == 0) {
         memcpy(pipe0_reading_address, address, addr_width);
     }
-    if (child <= 6) {
+    if (child <= 5) {
         // For pipes 2-5, only write the LSB
         if (child < 2) {
             write_register(pgm_read_byte(&child_pipe[child]), address, addr_width);


### PR DESCRIPTION
Hello,

this pull request prevents an undefined behavior when calling openReadingPipe() with child == 6 caused by accessing element 6 of the array child_pipe.