### PR TITLE
links in CONTRIBUTING append link to CONTRIBUTING in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@ These are the current requirements for getting your code included in RF24:
 
 * Try your best to follow the rest of the code, if you're unsure then the NASA C style can help as it's closest to the current style: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950022400.pdf
 
-* Definetly follow PEP-8 if it's Python code.
+* Definetly follow [PEP-8](https://www.python.org/dev/peps/pep-0008/) if it's Python code.
 
-* Follow the Arduino IDE formatting style for Arduino examples
+* Follow the [Arduino IDE formatting style](https://www.arduino.cc/en/Reference/StyleGuide) for Arduino examples
 
 * Add doxygen-compatible documentation to any new functions you add, or update existing documentation if you change behaviour

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
-## See http://tmrh20.github.io/RF24 for all documentation
+# See http://tmrh20.github.io/RF24 for all documentation
 
 ### Check our [contributing guidelines](CONTRIBUTING.md) before opening a pull request

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 
-**See http://tmrh20.github.io/RF24 for all documentation**
+## See http://tmrh20.github.io/RF24 for all documentation
+
+### Check our [contributing guidelines](CONTRIBUTING.md) before opening a pull request


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14963867/93749651-206bb680-fbaf-11ea-9a24-cc0e75e43cdf.png)
I made the docs link stick out more, so it would be harder to miss. Also appended a link to the contributing guidelines.

![image](https://user-images.githubusercontent.com/14963867/93750156-e4852100-fbaf-11ea-8555-fb1818247465.png)

contributing guidelines now have embedded links for PEP8 and Arduino style guides, This should be more definitive then letting google determine what we mean.