### PR TITLE
embed doxygen link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ These are the current requirements for getting your code included in RF24:
 
 * Follow the [Arduino IDE formatting style](https://www.arduino.cc/en/Reference/StyleGuide) for Arduino examples
 
-* Add doxygen-compatible documentation to any new functions you add, or update existing documentation if you change behaviour
+* Add [doxygen-compatible documentation](https://www.doxygen.nl/manual/docblocks.html) to any new functions you add, or update existing documentation if you change behaviour


### PR DESCRIPTION
starting to get doxygen now. But the official reference manual seems a little vague. e.g. I can't find where the "@" (like `@param`) commands are explained/listed.

added link to "documenting the code section" to steer prospective contributors in the official direction.