### PR TITLE
use ack_payloads_enabled to full potential

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -633,8 +633,8 @@ bool RF24::begin(void)
     // Set 1500uS (minimum for 32B payload in ESB@250KBPS) timeouts, to make testing a little easier
     // WARNING: If this is ever lowered, either 250KBS mode with AA is broken or maximum packet
     // sizes must never be used. See documentation for a more complete explanation.
-    setRetries(5, 15);   
- 
+    setRetries(5, 15);
+
     // Then set the data rate to the slowest (and most reliable) speed supported by all
     // hardware.
     setDataRate(RF24_1MBPS);
@@ -662,7 +662,7 @@ bool RF24::begin(void)
     // Clear CONFIG register, Enable PTX, Power Up & 16-bit CRC
     // Do not write CE high so radio will remain in standby I mode
     // PTX should use only 22uA of power
-    write_register(NRF_CONFIG, (_BV(EN_CRC) | _BV(CRCO)) );    
+    write_register(NRF_CONFIG, (_BV(EN_CRC) | _BV(CRCO)) );
     config_reg = read_register(NRF_CONFIG);
 
     powerUp();
@@ -696,7 +696,7 @@ void RF24::startListening(void)
      * 3. Allows time for slower devices to update with the faster startListening() function prior to updating stopListening() & adjusting txDelay
      */
     config_reg |= _BV(PRIM_RX);
-    write_register(NRF_CONFIG,config_reg);
+    write_register(NRF_CONFIG, config_reg);
     write_register(NRF_STATUS, _BV(RX_DR) | _BV(TX_DS) | _BV(MAX_RT));
     ce(HIGH);
     // Restore the pipe0 adddress, if exists
@@ -705,11 +705,6 @@ void RF24::startListening(void)
     } else {
         closeReadingPipe(0);
     }
-
-    if(ack_payloads_enabled){
-        flush_tx();
-    }
-
 }
 
 /****************************************************************************/
@@ -721,12 +716,10 @@ void RF24::stopListening(void)
     ce(LOW);
 
     delayMicroseconds(txDelay);
-
-    if (read_register(FEATURE) & _BV(EN_ACK_PAY)) {
-        delayMicroseconds(txDelay); //200
+    if (ack_payloads_enabled){
         flush_tx();
     }
-    //flush_rx();
+
     config_reg &= ~_BV(PRIM_RX);
     write_register(NRF_CONFIG, (read_register(NRF_CONFIG)) & ~_BV(PRIM_RX));
 
@@ -1027,7 +1020,7 @@ bool RF24::txStandBy(uint32_t timeout, bool startTx)
 /****************************************************************************/
 
 void RF24::maskIRQ(bool tx, bool fail, bool rx)
-{    
+{
     /* clear the interrupt flags */
     config_reg &= ~(1 << MASK_MAX_RT | 1 << MASK_TX_DS | 1 << MASK_RX_DR);
     /* set the specified interrupt flags */
@@ -1279,21 +1272,34 @@ void RF24::disableDynamicPayloads(void)
 
 void RF24::enableAckPayload(void)
 {
-    //
-    // enable ack payload and dynamic payload features
-    //
+    // enable ack payloads and dynamic payload features
 
-    //toggle_features();
-    write_register(FEATURE, read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL));
+    if (!ack_payloads_enabled){
+        write_register(FEATURE, read_register(FEATURE) | _BV(EN_ACK_PAY) | _BV(EN_DPL));
 
-    IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
+        IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
 
-    //
-    // Enable dynamic payload on pipes 0 & 1
-    //
-    write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
-    dynamic_payloads_enabled = true;
-    ack_payloads_enabled = true;
+        //
+        // Enable dynamic payload on pipes 0 & 1
+        //
+        write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
+        dynamic_payloads_enabled = true;
+        ack_payloads_enabled = true;
+    }
+}
+
+/****************************************************************************/
+
+void RF24::disableAckPayload(void)
+{
+    // disable ack payloads (leave dynamic payload features as is)
+    if (ack_payloads_enabled){
+        write_register(FEATURE, read_register(FEATURE) | ~_BV(EN_ACK_PAY));
+
+        IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
+
+        ack_payloads_enabled = false;
+    }
 }
 
 /****************************************************************************/
@@ -1307,40 +1313,38 @@ void RF24::enableDynamicAck(void)
     write_register(FEATURE, read_register(FEATURE) | _BV(EN_DYN_ACK));
 
     IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
-
-
 }
 
 /****************************************************************************/
 
 void RF24::writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
 {
-    const uint8_t* current = reinterpret_cast<const uint8_t*>(buf);
+    if (ack_payloads_enabled){
+        const uint8_t* current = reinterpret_cast<const uint8_t*>(buf);
 
-    uint8_t data_len = rf24_min(len, 32);
+        uint8_t data_len = rf24_min(len, 32);
 
-    #if defined(RF24_LINUX)
-    beginTransaction();
-    uint8_t * ptx = spi_txbuff;
-    uint8_t size = data_len + 1 ; // Add register value to transmit buffer
-    *ptx++ =  W_ACK_PAYLOAD | ( pipe & 0x07 );
-    while ( data_len-- ){
-      *ptx++ =  *current++;
+        #if defined(RF24_LINUX)
+        beginTransaction();
+        uint8_t * ptx = spi_txbuff;
+        uint8_t size = data_len + 1 ; // Add register value to transmit buffer
+        *ptx++ =  W_ACK_PAYLOAD | ( pipe & 0x07 );
+        while ( data_len-- ){
+        *ptx++ =  *current++;
+        }
+
+        _SPI.transfern( (char *) spi_txbuff, size);
+        endTransaction();
+        #else
+        beginTransaction();
+        _SPI.transfer(W_ACK_PAYLOAD | (pipe & 0x07));
+
+        while (data_len--)
+            _SPI.transfer(*current++);
+
+        endTransaction();
+        #endif
     }
-
-    _SPI.transfern( (char *) spi_txbuff, size);
-    endTransaction();
-    #else
-    beginTransaction();
-    _SPI.transfer(W_ACK_PAYLOAD | (pipe & 0x07));
-
-    while (data_len--) {
-        _SPI.transfer(*current++);
-    }
-    endTransaction();
-
-    #endif
-
 }
 
 /****************************************************************************/
@@ -1364,10 +1368,14 @@ bool RF24::isPVariant(void)
 
 void RF24::setAutoAck(bool enable)
 {
-    if (enable) {
+    if (enable){
         write_register(EN_AA, 0x3F);
-    } else {
+    }else{
         write_register(EN_AA, 0);
+        // accomodate ACK payloads feature
+        if (ack_payloads_enabled){
+            disableAckPayload();
+        }
     }
 }
 
@@ -1375,12 +1383,15 @@ void RF24::setAutoAck(bool enable)
 
 void RF24::setAutoAck(uint8_t pipe, bool enable)
 {
-    if (pipe <= 6) {
+    if (pipe < 6) {
         uint8_t en_aa = read_register(EN_AA);
         if (enable) {
             en_aa |= _BV(pipe);
-        } else {
+        }else{
             en_aa &= ~_BV(pipe);
+            if (ack_payloads_enabled && !pipe){
+                disableAckPayload();
+            }
         }
         write_register(EN_AA, en_aa);
     }
@@ -1524,7 +1535,7 @@ rf24_crclength_e RF24::getCRCLength(void)
     rf24_crclength_e result = RF24_CRC_DISABLED;
     uint8_t AA = read_register(EN_AA);
     config_reg = read_register(NRF_CONFIG);
-    
+
     if (config_reg & _BV(EN_CRC) || AA) {
         if (config_reg & _BV(CRCO)) {
             result = RF24_CRC_16;
@@ -1563,7 +1574,7 @@ void RF24::startConstCarrier(rf24_pa_dbm_e level, uint8_t channel )
 
 /****************************************************************************/
 void RF24::stopConstCarrier()
-{   
+{
     write_register(RF_SETUP, (read_register(RF_SETUP)) & ~_BV(CONT_WAVE));
     write_register(RF_SETUP, (read_register(RF_SETUP)) & ~_BV(PLL_LOCK));
     ce(LOW);

--- a/RF24.h
+++ b/RF24.h
@@ -173,6 +173,10 @@ public:
      * radio.stopListening();
      * radio.write(&data,sizeof(data));
      * @endcode
+     *
+     * @note The TX FIFO is flushed when calling this function. This is meant
+     * to discard any ACK payloads that were not appended to acknowledgment
+     * packets.
      */
     void stopListening(void);
 
@@ -820,6 +824,13 @@ public:
     void enableAckPayload(void);
 
     /**
+     * Disable custom payloads on the ackowledge packets
+     *
+     * @see enableAckPayload()
+     */
+    void disableAckPayload(void);
+
+    /**
      * Enable dynamically-sized payloads
      *
      * This way you don't always have to send large packets just to send them
@@ -867,18 +878,26 @@ public:
      * This is enabled by default, so it's only needed if you want to turn
      * it off for some reason.
      *
-     * @param enable Whether to enable (true) or disable (false) auto-acks
+     * @note If disabling auto-acknowledgment packets, the ACK payloads
+     * feature is also disabled.
+     *
+     * @param enable Whether to enable (true) or disable (false)
+     * auto-acknowledgments
      */
     void setAutoAck(bool enable);
 
     /**
-     * Enable or disable auto-acknowlede packets on a per pipeline basis.
+     * Enable or disable auto-acknowledgment packets on a per pipeline basis.
      *
      * AA is enabled by default, so it's only needed if you want to turn
      * it off/on for some reason on a per pipeline basis.
      *
+     * @note If disabling auto-acknowledgment packets on pipe 0, the ACK
+     * payloads feature is also disabled.
+     *
      * @param pipe Which pipeline to modify
-     * @param enable Whether to enable (true) or disable (false) auto-acks
+     * @param enable Whether to enable (true) or disable (false)
+     * auto-acknowledgment
      */
     void setAutoAck(uint8_t pipe, bool enable);
 
@@ -889,7 +908,7 @@ public:
      * The power levels correspond to the following output levels respectively:
      * NRF24L01: -18dBm, -12dBm,-6dBM, and 0dBm, lnaEnable affects modules with LNA
      *
-     * SI24R1: -6dBm, 0dBm, 3dBm and 7dBm with lnaEnable = 1 
+     * SI24R1: -6dBm, 0dBm, 3dBm and 7dBm with lnaEnable = 1
      *        -12dBm,-4dBm, 1dBm and 4dBm with lnaEnable = 0
      *
      * @param level Desired PA level.
@@ -1001,14 +1020,14 @@ public:
 
     /**
      * Transmission of constant carrier wave with defined frequency and output power
-     * 
+     *
      * @param level Output power to use
      * @param channel The channel to use
-     */    
+     */
     void startConstCarrier(rf24_pa_dbm_e level, uint8_t channel);
 
     /**
-     * Stop transmission of constant wave and reset PLL and CONT registers  
+     * Stop transmission of constant wave and reset PLL and CONT registers
      */
     void stopConstCarrier(void);
 
@@ -1460,7 +1479,7 @@ private:
  * - Minor fixes & changes
  *
  *
- * 
+ *
  * @section Useful Useful References
  *
  *
@@ -1476,8 +1495,8 @@ private:
  * @li <a href="http://tmrh20.github.io/RF24Mesh"> <b>RF24Mesh:</b> Dynamic Mesh Layer for RF24Network</a>
  * @li <a href="http://tmrh20.github.io/RF24Ethernet"> <b>RF24Ethernet:</b> TCP/IP Radio Mesh Networking (shares Arduino Ethernet API)</a>
  * @li <a href="http://tmrh20.github.io/RF24Audio"> <b>RF24Audio:</b> Realtime Wireless Audio streaming</a>
- * @li <a href="http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html"><b>My Blog:</b> RF24 Optimization Overview</a> 
- * @li <a href="http://tmrh20.blogspot.com/2016/08/raspberry-pilinux-with-nrf24l01.html"><b>My Blog:</b> RPi/Linux w/RF24Gateway</a> 
+ * @li <a href="http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html"><b>My Blog:</b> RF24 Optimization Overview</a>
+ * @li <a href="http://tmrh20.blogspot.com/2016/08/raspberry-pilinux-with-nrf24l01.html"><b>My Blog:</b> RPi/Linux w/RF24Gateway</a>
  * @li <a href="http://tmrh20.github.io/">All TMRh20 Documentation Main Page</a>
  *
  * **More Information**
@@ -1517,27 +1536,27 @@ private:
  *
  * @li [0] https://learn.sparkfun.com/tutorials/tiny-avr-programmer-hookup-guide/attiny85-use-hints
  * @li [1] http://highlowtech.org/?p=1695
- * @li [2] http://littlewire.cc/   
+ * @li [2] http://littlewire.cc/
  * <br><br><br>
  *
  *
  *
  *
  * @page Arduino Arduino
- * 
+ *
  * RF24 is fully compatible with Arduino boards <br>
  * See <b> http://www.arduino.cc/en/Reference/Board </b> and <b> http://arduino.cc/en/Reference/SPI </b> for more information
- * 
+ *
  * RF24 makes use of the standard hardware SPI pins (MISO,MOSI,SCK) and requires two additional pins, to control
  * the chip-select and chip-enable functions.<br>
- * These pins must be chosen and designated by the user, in RF24 radio(ce_pin,cs_pin); and can use any 
+ * These pins must be chosen and designated by the user, in RF24 radio(ce_pin,cs_pin); and can use any
  * available pins.
- * 
+ *
  * <br>
  * @section Alternate_SPI Alternate SPI Support
  *
  * RF24 supports alternate SPI methods, in case the standard hardware SPI pins are otherwise unavailable.
- * 
+ *
  * <br>
  * **Software Driven SPI**
  *
@@ -1545,8 +1564,8 @@ private:
  *
  * Setup:<br>
  * 1. Install the digitalIO library<br>
- * 2. Open RF24_config.h in a text editor. 
-      Uncomment the line 
+ * 2. Open RF24_config.h in a text editor.
+      Uncomment the line
       @code
       #define SOFTSPI
       @endcode
@@ -1571,11 +1590,11 @@ private:
  * <br>
  * **Alternate Hardware (UART) Driven  SPI**
  *
- * The Serial Port (UART) on Arduino can also function in SPI mode, and can double-buffer data, while the 
+ * The Serial Port (UART) on Arduino can also function in SPI mode, and can double-buffer data, while the
  * default SPI hardware cannot.
  *
  * The SPI_UART library is available at https://github.com/TMRh20/Sketches/tree/master/SPI_UART
- * 
+ *
  * Enabling:
  * 1. Install the SPI_UART library
  * 2. Edit RF24_config.h and uncomment `#define SPI_UART`
@@ -1593,12 +1612,12 @@ private:
  *
  * @note SPI_UART on Mega boards requires soldering to an unused pin on the chip. <br>See
  * https://github.com/TMRh20/RF24/issues/24 for more information on SPI_UART.
- * 
+ *
  * @page ATTiny ATTiny
  *
  * ATTiny support is built into the library, so users are not required to include SPI.h in their sketches<br>
  * See the included rf24ping85 example for pin info and usage
- * 
+ *
  * Some versions of Arduino IDE may require a patch to allow use of the full program space on ATTiny<br>
  * See https://github.com/TCWORLD/ATTinyCore/tree/master/PCREL%20Patch%20for%20GCC for ATTiny patch
  *
@@ -1606,7 +1625,7 @@ private:
  *
  * @section Hardware Hardware Configuration
  * By tong67 ( https://github.com/tong67 )
- * 
+ *
  *    **ATtiny25/45/85 Pin map with CE_PIN 3 and CSN_PIN 4**
  * @code
  *                                 +-\/-+
@@ -1614,7 +1633,7 @@ private:
  *    nRF24L01  CE, pin3 --- PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5
  *    nRF24L01 CSN, pin4 --- PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6
  *    nRF24L01 GND, pin1 --- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7
- *                                 +----+ 
+ *                                 +----+
  * @endcode
  *
  * <br>
@@ -1625,22 +1644,22 @@ private:
  *    This configuration is enabled when CE_PIN and CSN_PIN are equal, e.g. both 3                      <br>
  *    Because CE is always high the power consumption is higher than for 5 pins solution                <br>
  * @code
- *                                                                                           ^^         
- *                                 +-\/-+           nRF24L01   CE, pin3 ------|              //         
- *                           PB5  1|o   |8  Vcc --- nRF24L01  VCC, pin2 ------x----------x--|<|-- 5V    
- *                   NC      PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5 --|<|---x-[22k]--|  LED         
- *                   NC      PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6  1n4148 |                       
- *    nRF24L01 GND, pin1 -x- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7         |                       
- *                        |        +----+                                       |                       
- *                        |-----------------------------------------------||----x-- nRF24L01 CSN, pin4  
- *                                                                      10nF                            
+ *                                                                                           ^^
+ *                                 +-\/-+           nRF24L01   CE, pin3 ------|              //
+ *                           PB5  1|o   |8  Vcc --- nRF24L01  VCC, pin2 ------x----------x--|<|-- 5V
+ *                   NC      PB3  2|    |7  PB2 --- nRF24L01  SCK, pin5 --|<|---x-[22k]--|  LED
+ *                   NC      PB4  3|    |6  PB1 --- nRF24L01 MOSI, pin6  1n4148 |
+ *    nRF24L01 GND, pin1 -x- GND  4|    |5  PB0 --- nRF24L01 MISO, pin7         |
+ *                        |        +----+                                       |
+ *                        |-----------------------------------------------||----x-- nRF24L01 CSN, pin4
+ *                                                                      10nF
  * @endcode
  *
  * <br>
  *    **ATtiny24/44/84 Pin map with CE_PIN 8 and CSN_PIN 7** <br>
  *	Schematic provided and successfully tested by Carmine Pastore (https://github.com/Carminepz) <br>
  * @code
- *                                  +-\/-+                                                              
+ *                                  +-\/-+
  *    nRF24L01  VCC, pin2 --- VCC  1|o   |14 GND --- nRF24L01  GND, pin1
  *                            PB0  2|    |13 AREF
  *                            PB1  3|    |12 PA1
@@ -1649,12 +1668,12 @@ private:
  *                            PA7  6|    |9  PA4 --- nRF24L01  SCK, pin5
  *    nRF24L01 MISO, pin7 --- PA6  7|    |8  PA5 --- nRF24L01 MOSI, pin6
  *                                  +----+
- *	@endcode					 
- *	
+ *	@endcode
+ *
  * <br>
  *    **ATtiny2313/4313 Pin map with CE_PIN 12 and CSN_PIN 13** <br>
  * @code
- *                                  +-\/-+                                                              
+ *                                  +-\/-+
  *                            PA2  1|o   |20 VCC --- nRF24L01  VCC, pin2
  *                            PD0  2|    |19 PB7 --- nRF24L01  SCK, pin5
  *                            PD1  3|    |18 PB6 --- nRF24L01 MOSI, pin6
@@ -1666,13 +1685,13 @@ private:
  *                            PD5  9|    |12 PB0
  *    nRF24L01  GND, pin1 --- GND 10|    |11 PD6
  *                                  +----+
- *	@endcode					 
+ *	@endcode
  *
  * <br><br><br>
  *
  *
- * 
- * 
+ *
+ *
  *
  *
  * @page Linux Linux Installation
@@ -1682,10 +1701,10 @@ private:
  *  @note The SPIDEV option should work with most Linux systems supporting spi userspace device. <br>
  *
  * <br>
- * @section AutoInstall Automated Install 
+ * @section AutoInstall Automated Install
  *(**Designed & Tested on RPi** - Defaults to SPIDEV on devices supporting it)
  *
- * 
+ *
  * 1. Install prerequisites if there are any (MRAA, LittleWire libraries, setup SPI device etc)
  * 2. Download the install.sh file from http://tmrh20.github.io/RF24Installer/RPi/install.sh
  * @code wget http://tmrh20.github.io/RF24Installer/RPi/install.sh @endcode
@@ -1694,13 +1713,13 @@ private:
  * 4. Run it and choose your options
  * @code ./install.sh @endcode
  * 5. Run an example from one of the libraries
- * @code 
- * cd rf24libs/RF24/examples_linux  
+ * @code
+ * cd rf24libs/RF24/examples_linux
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
  * @code nano gettingstarted.cpp
- * make  
- * sudo ./gettingstarted  
+ * make
+ * sudo ./gettingstarted
  * @endcode
  *
  * <br>
@@ -1709,7 +1728,7 @@ private:
  * @note See the <a href="http://iotdk.intel.com/docs/master/mraa/index.html">MRAA </a> documentation for more info on installing MRAA <br>
  * 2. Make a directory to contain the RF24 and possibly RF24Network lib and enter it
  * @code
- *  mkdir ~/rf24libs 
+ *  mkdir ~/rf24libs
  *  cd ~/rf24libs
 *  @endcode
  * 3. Clone the RF24 repo
@@ -1720,11 +1739,11 @@ private:
  * 6. Build the library, and run an example file
  * @code make; sudo make install @endcode
  * @code
- * cd examples_linux  
+ * cd examples_linux
  * @endcode
  * Edit the gettingstarted example, to set your pin configuration
- * @code nano gettingstarted.cpp 
- * make 
+ * @code nano gettingstarted.cpp
+ * make
  * sudo ./gettingstarted
  * @endcode
  *
@@ -1738,9 +1757,9 @@ private:
  * @endcode
  * 3. See the gettingstarted example for an example of pin configuration
  * <br><br>
- *   
+ *
  * @page MRAA MRAA
- *  
+ *
  * MRAA is a Low Level Skeleton Library for Communication on GNU/Linux platforms <br>
  * See http://iotdk.intel.com/docs/master/mraa/index.html for more information
  *
@@ -1773,15 +1792,15 @@ private:
  *
  * <br><br><br>
  *
- * 
  *
  *
- * @page RPi Linux General/Raspberry Pi 
+ *
+ * @page RPi Linux General/Raspberry Pi
  *
  * RF24 supports a variety of Linux based devices via various drivers. Some boards like RPi can utilize multiple methods
  * to drive the GPIO and SPI functionality.
  *
- * 
+ *
  * @section PreConfig Potential PreConfiguration
  *
  * If SPI is not already enabled, load it on boot:
@@ -1790,7 +1809,7 @@ private:
  * B. Select **Advanced** and **enable the SPI kernel module** <br>
  * C. Update other software and libraries
  * @code sudo apt-get update @endcode
- * @code sudo apt-get upgrade @endcode 
+ * @code sudo apt-get upgrade @endcode
  * <br>
  *
  * @section Build Build Options
@@ -1807,11 +1826,11 @@ private:
  * Using pin 15/GPIO 22 for CE, pin 24/GPIO8 (CE0) for CSN
  *
  * Can use any available SPI BUS for CSN.<br>
- * In general, use @code RF24 radio(<ce_pin>, <a>*10+<b>); @endcode for proper constructor to 
- * address correct spi device at /dev/spidev\<a\>.\<b\> 
+ * In general, use @code RF24 radio(<ce_pin>, <a>*10+<b>); @endcode for proper constructor to
+ * address correct spi device at /dev/spidev\<a\>.\<b\>
  * <br>
  * Choose any GPIO output pin for radio CE pin.
- * 
+ *
  * **General:**
  * @code RF24 radio(22,0); @endcode
  *
@@ -1824,11 +1843,11 @@ private:
  * **SPI_DEV Constructor**
  *
  * @code RF24 radio(22,0); @endcode
- * 
+ *
  *
  * https://www.raspberrypi.org/documentation/usage/gpio/
  *
- * **Pins:**  
+ * **Pins:**
  *
  * | PIN | NRF24L01 |    RPI     | RPi -P1 Connector |
  * |-----|----------|------------|-------------------|
@@ -1840,29 +1859,29 @@ private:
  * |  6  |   MOSI   | rpi-mosi   |     (19)          |
  * |  7  |   MISO   | rpi-miso   |     (21)          |
  * |  8  |   IRQ    |    -       |       -           |
- *   
- *   
- *  
- *  
+ *
+ *
+ *
+ *
  * <br><br>
  ****************
- *   
+ *
  * Based on the arduino lib from J. Coliz <maniacbug@ymail.com>  <br>
- * the library was berryfied by Purinda Gunasekara <purinda@gmail.com> <br>  
+ * the library was berryfied by Purinda Gunasekara <purinda@gmail.com> <br>
  * then forked from github stanleyseow/RF24 to https://github.com/jscrane/RF24-rpi  <br>
  * Network lib also based on https://github.com/farconada/RF24Network
  *
- * 
  *
- * 
+ *
+ *
  * <br><br><br>
- * 
  *
- *  
+ *
+ *
  * @page Python Python Wrapper (by https://github.com/mz-fuzzy)
  *
  * @section Prerequisites Prerequisites
- * 
+ *
  * <b>Python2:</b>
  *
  * @code sudo apt-get install python-dev libboost-python-dev python-setuptools python-rpi.gpio @endcode
@@ -1887,19 +1906,19 @@ private:
  * 3. Install the library
  * @code sudo ./setup.py install  @endcode or @code sudo python3 setup.py install @endcode
  * See the additional <a href="pages.html">Platform Support</a> pages for information on connecting your hardware  <br>
- * See the included <a href="pingpair_dyn_8py-example.html">example </a> for usage information.   
- * 
+ * See the included <a href="pingpair_dyn_8py-example.html">example </a> for usage information.
+ *
  * 5. Running the Example: <br>
- * Edit the pingpair_dyn.py example to configure the appropriate pins per the above documentation:  
+ * Edit the pingpair_dyn.py example to configure the appropriate pins per the above documentation:
  * @code nano pingpair_dyn.py   @endcode
  * Configure another device, Arduino or RPi with the <a href="pingpair_dyn_8py-example.html">pingpair_dyn</a> example <br>
- * Run the example  
+ * Run the example
  * @code sudo ./pingpair_dyn.py  @endcode or @code sudo python3 pingpair_dyn.py @endcode
  *
  * <br><br><br>
  *
  * @page CrossCompile Linux cross-compilation
- * 
+ *
  * RF24 library supports cross-compilation. Advantages of cross-compilation:
  *  - development tools don't have to be installed on target machine
  *  - resources of target machine don't have to be sufficient for compilation
@@ -1972,16 +1991,16 @@ private:
  * <br><br><br>
  *
  * @page ATXMEGA ATXMEGA
- * 
+ *
  * The RF24 driver can be build as a static library with Atmel Studio 7 in order to be included as any other library in another program for the XMEGA family.
  *
  * Currently only the <b>ATXMEGA D3</b> family is implemented.
- * 
- * @section Preparation 
- * 
+ *
+ * @section Preparation
+ *
  * Create an empty GCC Static Library project in AS7.<br>
  * As not all files are required, copy the following directory structure in the project:
- * 
+ *
  * @code
  * utility\
  *   ATXMegaD3\
@@ -2001,38 +2020,38 @@ private:
  * RF24.h
  * RF24_config.h
  * @endcode
- * 
+ *
  * @section Usage
- * 
+ *
  * Add the library to your project!<br>
  * In the file where the **main()** is put the following in order to update the millisecond functionality:
- * 
+ *
  * @code
  * ISR(TCE0_OVF_vect)
  * {
  * 	update_milisec();
  * }
  * @endcode
- * 
+ *
  * Declare the rf24 radio with **RF24 radio(XMEGA_PORTC_PIN3, XMEGA_SPI_PORT_C);**
- * 
+ *
  * First parameter is the CE pin which can be any available pin on the uC.
- * 
- * Second parameter is the CS which can be on port C (**XMEGA_SPI_PORT_C**) or on port D (**XMEGA_SPI_PORT_D**). 
- * 
+ *
+ * Second parameter is the CS which can be on port C (**XMEGA_SPI_PORT_C**) or on port D (**XMEGA_SPI_PORT_D**).
+ *
  * Call the **__start_timer()** to start the millisecond timer.
- * 
+ *
  * @note Note about the millisecond functionality:<br>
- * 
+ *
  * 	The millisecond functionality is based on the TCE0 so don't use these pins as IO.<br>
- * 	The operating frequency of the uC is 32MHz. If you have other frequency change the TCE0 registers appropriatly in function **__start_timer()** in **compatibility.c** file for your frequency. 
+ * 	The operating frequency of the uC is 32MHz. If you have other frequency change the TCE0 registers appropriatly in function **__start_timer()** in **compatibility.c** file for your frequency.
  *
  * @page Portability RF24 Portability
  *
  * The RF24 radio driver mainly utilizes the <a href="http://arduino.cc/en/reference/homePage">Arduino API</a> for GPIO, SPI, and timing functions, which are easily replicated
- * on various platforms. <br>Support files for these platforms are stored under RF24/utility, and can be modified to provide 
+ * on various platforms. <br>Support files for these platforms are stored under RF24/utility, and can be modified to provide
  * the required functionality.
- * 
+ *
  * <br>
  * @section Hardware_Templates Basic Hardware Template
  *
@@ -2041,18 +2060,18 @@ private:
  * The RF24 library now includes a basic hardware template to assist in porting to various platforms. <br> The following files can be included
  * to replicate standard Arduino functions as needed, allowing devices from ATTiny to Raspberry Pi to utilize the same core RF24 driver.
  *
- * | File               |                   Purpose                                                    | 
- * |--------------------|------------------------------------------------------------------------------| 
- * | RF24_arch_config.h | Basic Arduino/AVR compatibility, includes for remaining support files, etc   | 
- * | includes.h         | Linux only. Defines specific platform, include correct RF24_arch_config file | 
- * | spi.h              | Provides standardized SPI ( transfer() ) methods                         | 
- * | gpio.h             | Provides standardized GPIO ( digitalWrite() ) methods                        | 
- * | compatibility.h    | Provides standardized timing (millis(), delay()) methods                     | 
- * | your_custom_file.h | Provides access to custom drivers for spi,gpio, etc                          | 
+ * | File               |                   Purpose                                                    |
+ * |--------------------|------------------------------------------------------------------------------|
+ * | RF24_arch_config.h | Basic Arduino/AVR compatibility, includes for remaining support files, etc   |
+ * | includes.h         | Linux only. Defines specific platform, include correct RF24_arch_config file |
+ * | spi.h              | Provides standardized SPI ( transfer() ) methods                         |
+ * | gpio.h             | Provides standardized GPIO ( digitalWrite() ) methods                        |
+ * | compatibility.h    | Provides standardized timing (millis(), delay()) methods                     |
+ * | your_custom_file.h | Provides access to custom drivers for spi,gpio, etc                          |
  *
  * <br>
  * Examples are provided via the included hardware support templates in **RF24/utility** <br>
- * See the <a href="modules.html">modules</a> page for examples of class declarations 
+ * See the <a href="modules.html">modules</a> page for examples of class declarations
  *
  *<br>
  * @section Device_Detection Device Detection
@@ -2064,7 +2083,7 @@ private:
  * <br>
  * @section Ported_Code Code
  * To have your ported code included in this library, or for assistance in porting, create a pull request or open an issue at https://github.com/TMRh20/RF24
- * 
+ *
  *
  *<br><br><br>
  */


### PR DESCRIPTION
addresses #654 

Also, I found an [error in the comparison statement](https://github.com/nRF24/RF24/blob/a3f9ace8c530138bd10211a08bc498f05187edb7/RF24.cpp#L1378) used in `setAutoAck()` about the pipe number passed to the `pipe` parameter. There is no pipe 6 (only 0-5). While the datasheet says "only 0s allowed", the bit in the EN_AA register is marked read/write. The fact that this hasn't caused an error with the nRF24L01 justifies #641 because if you assert bit 6 in the EN_AA, then a SPI read transaction will return 1 in bit position 6 of the EN_AA register (tested this with my circuitpython library's SPI functions when I developed per pipe control of auto-ack).

## about startListening() in reUseTx() docs
I made some doc changes to `reUseTx()` about `startListening()` currently flushing the TX FIFO in #656. With this PR, `startListening()` no longer flushes the TX FIFO (see Additional context in #654). So the doc changes in #656 should reflect this PR as well, but this branch is not based on the branch used for #656.