### PR TITLE
Make RF24_POWERUP_DELAY configurable in RF24_config.h

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -765,7 +765,7 @@ void RF24::powerUp(void)
         // For nRF24L01+ to go from power down mode to TX or RX mode it must first pass through stand-by mode.
         // There must be a delay of Tpd2stby (see Table 16.) after the nRF24L01+ leaves power down mode before
         // the CEis set high. - Tpd2stby can be up to 5ms per the 1.0 datasheet
-        delay(RF24_POWERUP_DELAY_MS);
+        delayMicroseconds(RF24_POWERUP_DELAY);
     }
 }
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -755,7 +755,7 @@ void RF24::powerDown(void)
 /****************************************************************************/
 
 //Power up now. Radio will not power down unless instructed by MCU for config changes etc.
-void RF24::powerUp(bool wait)
+void RF24::powerUp(void)
 {
     // if not powered up then power up and wait for the radio to initialize
     if (!(config_reg & _BV(PWR_UP))) {
@@ -765,8 +765,7 @@ void RF24::powerUp(bool wait)
         // For nRF24L01+ to go from power down mode to TX or RX mode it must first pass through stand-by mode.
         // There must be a delay of Tpd2stby (see Table 16.) after the nRF24L01+ leaves power down mode before
         // the CEis set high. - Tpd2stby can be up to 5ms per the 1.0 datasheet
-	if (wait)
-            delay(5);
+        delay(5);
     }
 }
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -765,7 +765,7 @@ void RF24::powerUp(void)
         // For nRF24L01+ to go from power down mode to TX or RX mode it must first pass through stand-by mode.
         // There must be a delay of Tpd2stby (see Table 16.) after the nRF24L01+ leaves power down mode before
         // the CEis set high. - Tpd2stby can be up to 5ms per the 1.0 datasheet
-        delay(5);
+        delay(RF24_POWERUP_DELAY_MS);
     }
 }
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -755,7 +755,7 @@ void RF24::powerDown(void)
 /****************************************************************************/
 
 //Power up now. Radio will not power down unless instructed by MCU for config changes etc.
-void RF24::powerUp(void)
+void RF24::powerUp(bool wait)
 {
     // if not powered up then power up and wait for the radio to initialize
     if (!(config_reg & _BV(PWR_UP))) {
@@ -765,7 +765,8 @@ void RF24::powerUp(void)
         // For nRF24L01+ to go from power down mode to TX or RX mode it must first pass through stand-by mode.
         // There must be a delay of Tpd2stby (see Table 16.) after the nRF24L01+ leaves power down mode before
         // the CEis set high. - Tpd2stby can be up to 5ms per the 1.0 datasheet
-        delay(5);
+	if (wait)
+            delay(5);
     }
 }
 

--- a/RF24.h
+++ b/RF24.h
@@ -385,7 +385,7 @@ public:
      * To return to low power mode, call powerDown().
      * @note This will take up to 5ms for maximum compatibility
      */
-    void powerUp(void);
+    void powerUp(bool wait = true);
 
     /**
     * Write for single NOACK writes. Optionally disables acknowledgements/autoretries for a single write.

--- a/RF24.h
+++ b/RF24.h
@@ -385,7 +385,7 @@ public:
      * To return to low power mode, call powerDown().
      * @note This will take up to 5ms for maximum compatibility
      */
-    void powerUp(bool wait = true);
+    void powerUp(void);
 
     /**
     * Write for single NOACK writes. Optionally disables acknowledgements/autoretries for a single write.

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -18,15 +18,16 @@
 #ifndef __RF24_CONFIG_H__
 #define __RF24_CONFIG_H__
 
-/*** USER DEFINES:    ***/    
+/*** USER DEFINES:    ***/
 #define FAILURE_HANDLING
 //#define SERIAL_DEBUG
 //#define MINIMAL
 //#define SPI_UART    // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
 //#define SOFTSPI     // Requires library from https://github.com/greiman/DigitalIO
-    
-#if !defined(RF24_POWERUP_DELAY_MS)
-#define RF24_POWERUP_DELAY_MS	5
+ 
+/** User access to internally used delay time (in microseconds) during RF24::powerUp() */
+#if !defined(RF24_POWERUP_DELAY)
+#define RF24_POWERUP_DELAY	5000
 #endif
 
 /**********************/

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -25,6 +25,10 @@
 //#define SPI_UART    // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
 //#define SOFTSPI     // Requires library from https://github.com/greiman/DigitalIO
     
+#if !defined(RF24_POWERUP_DELAY_MS)
+#define RF24_POWERUP_DELAY_MS	5
+#endif
+
 /**********************/
 #define rf24_max(a,b) (a>b?a:b)
 #define rf24_min(a,b) (a<b?a:b)

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -25,7 +25,11 @@
 //#define SPI_UART    // Requires library from https://github.com/TMRh20/Sketches/tree/master/SPI_UART
 //#define SOFTSPI     // Requires library from https://github.com/greiman/DigitalIO
  
-/** User access to internally used delay time (in microseconds) during RF24::powerUp() */
+/**
+ * User access to internally used delay time (in microseconds) during RF24::powerUp()
+ * @warning This default value compensates for all supported hardware. Only adjust this if you
+ * know your radio's hardware is, in fact, genuine and reliable.
+ */
 #if !defined(RF24_POWERUP_DELAY)
 #define RF24_POWERUP_DELAY	5000
 #endif


### PR DESCRIPTION
(This relates to #683 )

@2bndy5 if you have any further timings which could be usefully configured in this way, please ask!

(Also, apologies for all the commit noise below: hopefully git is smart enough to throw it away.)