### PR TITLE
follow-up fixes from #691

### DIFF
--- a/RF24.h
+++ b/RF24.h
@@ -2564,15 +2564,16 @@ private:
  *
  * 3. Install the library
  * @code sudo ./setup.py install  @endcode or @code sudo python3 setup.py install @endcode
- * See the additional <a href="pages.html">Platform Support</a> pages for information on connecting your hardware  <br>
- * See the included <a href="pingpair_dyn_8py-example.html">example </a> for usage information.
+ * See the additional <a href="pages.html">Platform Support pages</a> for information on connecting your hardware  <br>
  *
- * 5. Running the Example: <br>
- * Edit the pingpair_dyn.py example to configure the appropriate pins per the above documentation:
- * @code nano pingpair_dyn.py   @endcode
- * Configure another device, Arduino or RPi with the <a href="pingpair_dyn_8py-example.html">pingpair_dyn</a> example <br>
+ * See the included [*.py files in the "examples_linux" folder](examples.html) for usage information.
+ *
+ * 4. Running the Example: <br>
+ * Edit the getting_started.py example to configure the appropriate pins per the above documentation:
+ * @code nano getting_started.py   @endcode
+ * Configure another device, Arduino or RPi with the [getting_started.py example](examples_linux_2getting_started_8py-example.html)<br>
  * Run the example
- * @code sudo ./pingpair_dyn.py  @endcode or @code sudo python3 pingpair_dyn.py @endcode
+ * @code sudo python getting_started.py @endcode or @code sudo python3 getting_started.py @endcode
  *
  * <br><br><br>
  *

--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -119,15 +119,15 @@ void loop() {
     // This device is a RX node
 
     uint8_t pipe;
-    if (radio.available(&pipe)) {                    // is there a payload? get the pipe number that recieved it
-      uint8_t bytes = radio.getDynamicPayloadSize(); // get the size of the payload
-      radio.read(&payload, bytes);                   // fetch payload from FIFO
+    if (radio.available(&pipe)) {             // is there a payload? get the pipe number that recieved it
+      uint8_t bytes = radio.getPayloadSize(); // get the size of the payload
+      radio.read(&payload, bytes);            // fetch payload from FIFO
       Serial.print(F("Received "));
-      Serial.print(bytes);                           // print the size of the payload
+      Serial.print(bytes);                    // print the size of the payload
       Serial.print(F(" bytes on pipe "));
-      Serial.print(pipe);                            // print the pipe number
+      Serial.print(pipe);                     // print the pipe number
       Serial.print(F(": "));
-      Serial.println(payload);                       // print the payload's value
+      Serial.println(payload);                // print the payload's value
     }
   } // role
 

--- a/examples_linux/acknowledgementPayloads.cpp
+++ b/examples_linux/acknowledgementPayloads.cpp
@@ -12,7 +12,6 @@
  * Use `ctrl+c` to quit at any time.
  */
 #include <ctime>       // time()
-#include <cstring>     // strcmp()
 #include <iostream>    // cin, cout, endl
 #include <string>      // string, getline()
 #include <time.h>      // CLOCK_MONOTONIC_RAW, timespec, clock_gettime()

--- a/examples_linux/gettingstarted.cpp
+++ b/examples_linux/gettingstarted.cpp
@@ -163,7 +163,7 @@ void slave() {
     while (time(nullptr) - startTimer < 6) {                 // use 6 second timeout
         uint8_t pipe;
         if (radio.available(&pipe)) {                        // is there a payload? get the pipe number that recieved it
-            uint8_t bytes = radio.getDynamicPayloadSize();   // get the size of the payload
+            uint8_t bytes = radio.getPayloadSize();          // get the size of the payload
             radio.read(&payload, bytes);                     // fetch payload from FIFO
             cout << "Received " << (unsigned int)bytes;      // print the size of the payload
             cout << " bytes on pipe " << (unsigned int)pipe; // print the pipe number

--- a/examples_linux/gettingstarted.cpp
+++ b/examples_linux/gettingstarted.cpp
@@ -11,7 +11,6 @@
  * Use `ctrl+c` to quit at any time.
  */
 #include <ctime>       // time()
-#include <cstring>     // strcmp()
 #include <iostream>    // cin, cout, endl
 #include <string>      // string, getline()
 #include <time.h>      // CLOCK_MONOTONIC_RAW, timespec, clock_gettime()
@@ -189,18 +188,4 @@ uint32_t getMicros() {
     uint32_t useconds = (endTimer.tv_nsec - startTimer.tv_nsec) / 1000;
 
     return ((seconds) * 1000 + useconds) + 0.5;
-}
-
-
-/**
- * print a manual page of instructions on how to use this example's CLI args
- */
-void printHelp(string progName) {
-    cout << "usage: " << progName << " [-h] [-n {0,1}] [-r {0,1}]\n\n"
-         << "A simple example of sending data from 1 nRF24L01 transceiver to another.\n"
-         << "\nThis example was written to be used on 2 devices acting as 'nodes'.\n"
-         << "\noptional arguments:\n  -h, --help\t\tshow this help message and exit\n"
-         << "  -n {0,1}, --node {0,1}\n\t\t\tthe identifying radio number\n"
-         << "  -r {0,1}, --role {0,1}\n\t\t\t'1' specifies the TX role."
-         << " '0' specifies the RX role." << endl;
 }

--- a/examples_linux/interruptConfigure.cpp
+++ b/examples_linux/interruptConfigure.cpp
@@ -14,7 +14,6 @@
  * Use `ctrl+c` to quit at any time.
  */
 #include <ctime>       // time()
-#include <cstring>     // strcmp()
 #include <iostream>    // cin, cout, endl
 #include <string>      // string, getline()
 #include <time.h>      // CLOCK_MONOTONIC_RAW, timespec, clock_gettime()
@@ -317,22 +316,4 @@ void printRxFifo(const uint8_t pl_size) {
 
     // print the entire RX FIFO with 1 buffer
     cout << "Complete RX FIFO: " << rx_fifo << endl;
-}
-
-
-
-/**
- * print a manual page of instructions on how to use this example's CLI args
- */
-void printHelp(string progName) {
-    cout << "usage: " << progName << " [-h] [-n {0,1}] [-r {0,1}]\n\n"
-         << "This example uses Acknowledgement (ACK) payloads attached to ACK packets to\n"
-         << "demonstrate how the nRF24L01's IRQ (Interrupt Request) pin can be\n"
-         << "configured to detect when data is received, or when data has transmitted\n"
-         << "successfully, or when data has failed to transmit.\n"
-         << "\nThis example was written to be used on 2 devices acting as 'nodes'.\n"
-         << "\noptional arguments:\n  -h, --help\t\tshow this help message and exit\n"
-         << "  -n {0,1}, --node {0,1}\n\t\t\tthe identifying radio number\n"
-         << "  -r {0,1}, --role {0,1}\n\t\t\t'1' specifies the TX role."
-         << " '0' specifies the RX role." << endl;
 }

--- a/examples_linux/manualAcknowledgements.cpp
+++ b/examples_linux/manualAcknowledgements.cpp
@@ -17,7 +17,6 @@
  * Use `ctrl+c` to quit at any time.
  */
 #include <ctime>       // time()
-#include <cstring>     // strcmp()
 #include <iostream>    // cin, cout, endl
 #include <string>      // string, getline()
 #include <time.h>      // CLOCK_MONOTONIC_RAW, timespec, clock_gettime()


### PR DESCRIPTION
since I rewrote all the linux examples I noticed the install instructions for the python wrapper direct the user to edit/run an example that no longer exists.

This is a quick fix for just that. (changes tested/rendered correctly on my local machine)