### PR TITLE
Fix print pretty

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -628,7 +628,7 @@ void RF24::printPrettyDetails(void) {
     "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(bool)(autoAck & 1) * 1]));
 
     config_reg = read_register(NRF_CONFIG);
-    printf_P(PSTR("Primary Mode\t\t= %cX\r\n"), config_reg & _BV(PWR_UP) ? 'T' : 'R');
+    printf_P(PSTR("Primary Mode\t\t= %cX\r\n"), config_reg & _BV(PRIM_RX) ? 'T' : 'R');
     print_address_register(PSTR("TX address\t"), TX_ADDR);
 
     uint8_t openPipes = read_register(EN_RXADDR);

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -631,7 +631,7 @@ void RF24::printPrettyDetails(void) {
         "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(bool)(autoAck) * 1]));
     } else {
         // representation per pipe
-        printf_P(PSTR("Auto Acknowledgment\t0b%c%c%c%c%c%c\r\n"),
+        printf_P(PSTR("Auto Acknowledgment\t= 0b%c%c%c%c%c%c\r\n"),
                  (char)((bool)(autoAck & _BV(ENAA_P5)) + 48),
                  (char)((bool)(autoAck & _BV(ENAA_P4)) + 48),
                  (char)((bool)(autoAck & _BV(ENAA_P3)) + 48),

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -619,13 +619,26 @@ void RF24::printPrettyDetails(void) {
     "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(bool)(features & _BV(EN_ACK_PAY)) * 1]));
 
     uint8_t dynPl = read_register(DYNPD);
-    uint8_t autoAck = read_register(EN_AA);
     printf_P(PSTR("Dynamic Payloads\t"
     PRIPSTR
     "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(dynPl && (features &_BV(EN_DPL))) * 1]));
-    printf_P(PSTR("Auto Acknowledgment\t"
-    PRIPSTR
-    "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(bool)(autoAck & 1) * 1]));
+
+    uint8_t autoAck = read_register(EN_AA);
+    if (autoAck == 0x3F || autoAck == 0) {
+        // all pipes have the same configuration about auto-ack feature
+        printf_P(PSTR("Auto Acknowledgment\t"
+        PRIPSTR
+        "\r\n"), (char*)pgm_read_ptr(&rf24_feature_e_str_P[(bool)(autoAck) * 1]));
+    } else {
+        // representation per pipe
+        printf_P(PSTR("Auto Acknowledgment\t0b%c%c%c%c%c%c\r\n"),
+                 (char)((bool)(autoAck & _BV(ENAA_P5) + 48)),
+                 (char)((bool)(autoAck & _BV(ENAA_P4) + 48)),
+                 (char)((bool)(autoAck & _BV(ENAA_P3) + 48)),
+                 (char)((bool)(autoAck & _BV(ENAA_P2) + 48)),
+                 (char)((bool)(autoAck & _BV(ENAA_P1) + 48)),
+                 (char)((bool)(autoAck & _BV(ENAA_P0) + 48)));
+    }
 
     config_reg = read_register(NRF_CONFIG);
     printf_P(PSTR("Primary Mode\t\t= %cX\r\n"), config_reg & _BV(PRIM_RX) ? 'T' : 'R');

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -632,12 +632,12 @@ void RF24::printPrettyDetails(void) {
     } else {
         // representation per pipe
         printf_P(PSTR("Auto Acknowledgment\t0b%c%c%c%c%c%c\r\n"),
-                 (char)((bool)(autoAck & _BV(ENAA_P5) + 48)),
-                 (char)((bool)(autoAck & _BV(ENAA_P4) + 48)),
-                 (char)((bool)(autoAck & _BV(ENAA_P3) + 48)),
-                 (char)((bool)(autoAck & _BV(ENAA_P2) + 48)),
-                 (char)((bool)(autoAck & _BV(ENAA_P1) + 48)),
-                 (char)((bool)(autoAck & _BV(ENAA_P0) + 48)));
+                 (char)((bool)(autoAck & _BV(ENAA_P5)) + 48),
+                 (char)((bool)(autoAck & _BV(ENAA_P4)) + 48),
+                 (char)((bool)(autoAck & _BV(ENAA_P3)) + 48),
+                 (char)((bool)(autoAck & _BV(ENAA_P2)) + 48),
+                 (char)((bool)(autoAck & _BV(ENAA_P1)) + 48),
+                 (char)((bool)(autoAck & _BV(ENAA_P0)) + 48));
     }
 
     config_reg = read_register(NRF_CONFIG);

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -641,7 +641,7 @@ void RF24::printPrettyDetails(void) {
     }
 
     config_reg = read_register(NRF_CONFIG);
-    printf_P(PSTR("Primary Mode\t\t= %cX\r\n"), config_reg & _BV(PRIM_RX) ? 'T' : 'R');
+    printf_P(PSTR("Primary Mode\t\t= %cX\r\n"), config_reg & _BV(PRIM_RX) ? 'R' : 'T');
     print_address_register(PSTR("TX address\t"), TX_ADDR);
 
     uint8_t openPipes = read_register(EN_RXADDR);

--- a/RF24.h
+++ b/RF24.h
@@ -478,7 +478,7 @@ public:
      * differs from printDetails() because it makes the information more
      * understandable without having to look up the datasheet or convert
      * hexadecimal to binary. Only use this function if your application can
-     * spare a few extra bytes of memory.
+     * spare extra bytes of memory.
      *
      * @warning Does nothing if stdout is not defined.  See fdevopen in stdio.h
      * The printf.h file is included with the library for Arduino.
@@ -490,6 +490,11 @@ public:
      *  ...
      * }
      * @endcode
+     *
+     * @note If the automatic acknowledgements feature is configured differently
+     * for each pipe, then a binary representation is used in which bits 0-5
+     * represent pipes 0-5 respectively. A `0` means the feature is disabled and
+     * a `1` means the feature is enabled.
      */
     void printPrettyDetails(void);
 


### PR DESCRIPTION
Fixes #706 and closes #716. Both fixes in this PR resolves errors noticed by @combs & @DrClaudio73

1. Use binary representation to show the auto-ack feature when configuration differs per pipe
2. Uses correct mnemonic to output "primary mode"

Tested changes using python wrapper; it works as expected.