### PR TITLE
Update MulticeiverDemo.ino

### DIFF
--- a/examples/MulticeiverDemo/MulticeiverDemo.ino
+++ b/examples/MulticeiverDemo/MulticeiverDemo.ino
@@ -38,7 +38,7 @@ uint64_t address[6] = {0x7878787878LL,
 // transmit and only 1 node to receive, we will use a negative value in our
 // role variable to signify this node is a receiver.
 // role variable is used to control whether this node is sending or receiving
-char role = 'R'; // 0-5 = TX node; any negative number = RX node
+char role = 'R'; // integers 0-5 = TX node; character 'R' or integer 82 = RX node
 
 // For this example, we'll be using a payload containing
 // a node ID number and a single integer number that will be incremented

--- a/examples_linux/multiceiverDemo.cpp
+++ b/examples_linux/multiceiverDemo.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
 
     // to use different addresses on a pair of radios, we need a variable to
     // uniquely identify which address this radio will use to transmit
-    unsigned int nodeNumber = 'R'; // 0 uses address[0] to transmit, 1 uses address[1] to transmit
+    unsigned int nodeNumber = 'R'; // integers 0-5 = TX node; character 'R' or integer 82 = RX node
 
     bool foundArgNode = false;
     if (argc > 1) {
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
         else if (strcmp(argv[1], "-n") == 0 || strcmp(argv[1], "--node") == 0) {
             // "-n" or "--node" has been specified
             foundArgNode = true;
-            if ((argv[2][0] - 48) < 6) {
+            if ((argv[2][0] - 48) < 6 && (argv[2][0] - 48) >= 0) {
                 nodeNumber = argv[2][0] - 48;
             }
             else if (argv[2][0] == 'R' || argv[2][0] == 'r') {


### PR DESCRIPTION
This changes a comment about the `role` variable declaration in multiceiverDemo.ino. Confusion arose in #732 

I also changed the corresponding comment in the Linux equivalent example, and I added a condition to avoid setting the role to an invalid value based on CLI arg input. 

Didn't test this yet, but I don't expect any probems.