### PR TITLE
Community appreciation

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -13,7 +13,7 @@ jobs:
         config-options:
           - "--soc=BCM2835 --driver=RPi"
           - "--soc=BCM2836 --driver=RPi"
-          - "--soc=BCM2835 --driver=wiringPi --extra-cflags=-I/usr/local/include"
+          # - "--soc=BCM2835 --driver=wiringPi --extra-cflags=-I/usr/local/include"
           - "--driver=SPIDEV"
 
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: provide WiringPi
         if: ${{ matrix.config-options == '--soc=BCM2835 --driver=wiringPi --extra-cflags=-I/usr/local/include' }}
         run: |
-          git clone https://github.com/CoRfr/WiringPi
+          git clone https://github.com/WiringPi/WiringPi
           cd WiringPi/wiringPi
           CC="arm-linux-gnueabihf-gcc -marm -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard" V=1 make -j5
           sudo make install

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1354,7 +1354,7 @@ void RF24::enableAckPayload(void)
 
         IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
 
-        // Enable dynamic payload on pipes 0
+        // Enable dynamic payload on pipes 0 & 1
         write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
         dynamic_payloads_enabled = true;
         ack_payloads_enabled = true;

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -754,7 +754,7 @@ bool RF24::begin(void)
     write_register(DYNPD, 0);         // disable dynamic payloads by default (for all pipes)
     dynamic_payloads_enabled = false;
     write_register(EN_AA, 0x3F);      // enable auto-ack on all pipes
-    write_register(EN_RXADDR, 3);     // close all RX pipes
+    write_register(EN_RXADDR, 3);     // only open RX pipes 0 & 1
     setPayloadSize(32);               // set static payload size to 32 (max) bytes by default
     setAddressWidth(5);               // set default address length to (max) 5 bytes
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -754,7 +754,7 @@ bool RF24::begin(void)
     write_register(DYNPD, 0);         // disable dynamic payloads by default (for all pipes)
     dynamic_payloads_enabled = false;
     write_register(EN_AA, 0x3F);      // enable auto-ack on all pipes
-    write_register(EN_RXADDR, 0);     // close all RX pipes
+    write_register(EN_RXADDR, 3);     // close all RX pipes
     setPayloadSize(32);               // set static payload size to 32 (max) bytes by default
     setAddressWidth(5);               // set default address length to (max) 5 bytes
 
@@ -1355,7 +1355,7 @@ void RF24::enableAckPayload(void)
         IF_SERIAL_DEBUG(printf("FEATURE=%i\r\n", read_register(FEATURE)));
 
         // Enable dynamic payload on pipes 0
-        write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P0));
+        write_register(DYNPD, read_register(DYNPD) | _BV(DPL_P1) | _BV(DPL_P0));
         dynamic_payloads_enabled = true;
         ack_payloads_enabled = true;
     }


### PR DESCRIPTION
This PR fixes a couple changes I made in #691 that seemed to upset community members concerning backward compatibility. 
1. open pipes 0 & 1 in `begin()`noticed in #734
2. `enableAckPayloads()` also enables dynamic payloads for pipe 1 automatically. Reddit and Arduino forum users have gotten quite upset about this one (to which my reaction has been "RTFD" or "pay more attention to examples' comments").

### Concerning WiringPi build
Also, I'm disabling the WiringPi CI build to discontinue "Linux build CI failed" notifications that I keep getting. I've successfully built WiringPi locally on my RPi2 (and subsequently RF24 built successfully) using upstream WiringPi repo... I think that libcrypt.so.1 is not available for cross-compilation on x86 Ubuntu, but it seems to ship with armhf-based OSs (like Raspberry Pi OS). Pretty sure that libcrypt is part of the libc6 std libs, but I may be wrong. Lastly, I've changed the Linux build workflow to use the upstream WiringPi fork per @CoRfr recommendation (but it is disabled anyway).