### PR TITLE
endorse COMMON_ISSUES.md in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (weather they know it or not).
+Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (whether they know it or not).
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Having issues with ACK not working correctly? Please see [common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md).
+Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (weather they know it or not).
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (weather they know it or not).
+Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (whether they know it or not).

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-
+Please read [about common issues](https://github.com/nRF24/RF24/blob/master/COMMON_ISSUES.md) first. It addresses the most common problems that people have (weather they know it or not).


### PR DESCRIPTION
This updates the prompt by directing users to read the COMMON_ISSUES.md file in the "Bug Report" template. Also I added the same prompt to the "Question" template as many of the question-labeled issues could be avoided by also reading it, but most humble people don't think their questions are bug-related.