### PR TITLE
undo latest changes to SoftSPI & add patches

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -509,11 +509,7 @@ void RF24::_init_obj()
 {
     // Use a pointer on the Arduino platform
     #if defined (RF24_SPI_PTR)
-        #if defined (SOFTSPI)
-    _spi = &spi;
-        #else  // !defined(SOFTSPI)
     _spi = &SPI;
-        #endif // !defined(SOFTSPI)
     #endif // defined (RF24_SPI_PTR)
 
     pipe0_reading_address[0] = 0;

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -89,7 +89,7 @@
             #endif // SOFT_SPI_SCK_PIN
 
             const uint8_t SPI_MODE = 0;
-            #define _SPI SoftSPI<SOFT_SPI_MISO_PIN, SOFT_SPI_MOSI_PIN, SOFT_SPI_SCK_PIN, SPI_MODE>
+            #define _SPI spi
 
 
         #elif defined (ARDUINO_SAM_DUE)

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -90,7 +90,7 @@
 
             const uint8_t SPI_MODE = 0;
             #define _SPI SoftSPI<SOFT_SPI_MISO_PIN, SOFT_SPI_MOSI_PIN, SOFT_SPI_SCK_PIN, SPI_MODE>
-            #define RF24_SPI_PTR
+
 
         #elif defined (ARDUINO_SAM_DUE)
             #include <SPI.h>

--- a/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
+++ b/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
@@ -99,7 +99,7 @@ void setup() {
 
     memcpy(payload.message, "World ", 6);                       // set the payload message
     // load the payload for the first received transmission on pipe 0
-    radio.writeAckPayload(1, &payload, sizeof(PayloadStruct));
+    radio.writeAckPayload(1, &payload, sizeof(payload));
 
     radio.startListening();                                     // put radio in RX mode
   }
@@ -201,7 +201,7 @@ void loop() {
       memcpy(payload.message, "World ", 6); // change payload message
 
       // load the payload for the first received transmission on pipe 0
-      radio.writeAckPayload(1, &payload, sizeof(PayloadStruct));
+      radio.writeAckPayload(1, &payload, sizeof(payload));
       radio.startListening();
     }
   }

--- a/examples/MulticeiverDemo/MulticeiverDemo.ino
+++ b/examples/MulticeiverDemo/MulticeiverDemo.ino
@@ -120,7 +120,7 @@ void loop() {
     payload.payloadID++;                                     // increment payload number
 
     // to make this example readable in the serial monitor
-    delay(500); // slow transmissions down by 1 second
+    delay(1000); // slow transmissions down by 1 second
 
   } else if (role == 'R') {
     // This device is the RX node

--- a/examples_linux/acknowledgementPayloads.cpp
+++ b/examples_linux/acknowledgementPayloads.cpp
@@ -154,13 +154,13 @@ void master() {
             uint8_t pipe;
             if (radio.available(&pipe)) {
                 PayloadStruct received;
-                radio.read(&received, sizeof(received));          // get incoming ACK payload
+                radio.read(&received, sizeof(received));             // get incoming ACK payload
                 cout << " Received ";
-                cout << radio.getDynamicPayloadSize();            // print incoming payload size
-                cout << " bytes on pipe " << (unsigned int)pipe;  // print pipe that received it
-                cout << ": " << received.message;                 // print incoming message
-                cout << (unsigned int)received.counter << endl;   // print incoming counter
-                payload.counter = received.counter + 1;           // save incoming counter & increment for next outgoing
+                cout << (unsigned int)radio.getDynamicPayloadSize(); // print incoming payload size
+                cout << " bytes on pipe " << (unsigned int)pipe;     // print pipe that received it
+                cout << ": " << received.message;                    // print incoming message
+                cout << (unsigned int)received.counter << endl;      // print incoming counter
+                payload.counter = received.counter + 1;              // save incoming counter & increment for next outgoing
             } // if got an ACK payload
             else {
                 cout << " Received an empty ACK packet." << endl; // ACK had no payload

--- a/examples_linux/acknowledgement_payloads.py
+++ b/examples_linux/acknowledgement_payloads.py
@@ -135,7 +135,7 @@ def slave(timeout=6):
             radio.writeAckPayload(1, buffer)  # load ACK for next response
             start_timer = time.monotonic()  # reset timer
 
-    print("Nothing received in 6 seconds. Leaving RX role")
+    print("Nothing received in", timeout, "seconds. Leaving RX role")
     # recommended behavior is to keep in TX mode while idle
     radio.stopListening()  # put radio in TX mode & flush unused ACK payloads
 

--- a/examples_linux/getting_started.py
+++ b/examples_linux/getting_started.py
@@ -105,7 +105,7 @@ def slave(timeout=6):
             )
             start_timer = time.monotonic()  # reset the timeout timer
 
-    print("Nothing received in 6 seconds. Leaving RX role")
+    print("Nothing received in", timeout, "seconds. Leaving RX role")
     # recommended behavior is to keep in TX mode while idle
     radio.stopListening()  # put the radio in TX mode
 

--- a/examples_linux/manual_acknowledgements.py
+++ b/examples_linux/manual_acknowledgements.py
@@ -156,7 +156,7 @@ def slave(timeout=6):
                 print("Response failed or timed out")
             start_timer = time.monotonic()  # reset the timeout timer
 
-    print("Nothing received in 6 seconds. Leaving RX role")
+    print("Nothing received in", timeout, "seconds. Leaving RX role")
     # recommended behavior is to keep in TX mode while idle
     radio.stopListening()  # put the radio in TX mode
 

--- a/examples_linux/multiceiverDemo.cpp
+++ b/examples_linux/multiceiverDemo.cpp
@@ -207,7 +207,7 @@ void master(unsigned int role) {
         payload.payloadID++;                                   // increment payload number
 
         // to make this example readable in the terminal
-        delay(500); // slow transmissions down by 0.5 second
+        delay(1000); // slow transmissions down by 1 second
     } // while
     cout << failures << " failures detected. Leaving TX role." << endl;
 } // master

--- a/examples_linux/multiceiver_demo.py
+++ b/examples_linux/multiceiver_demo.py
@@ -60,6 +60,11 @@ def master(node_number):
     :param int node_number: the node's identifying index (from the
         the `addresses` list). This is a required parameter
     """
+    # According to the datasheet, the auto-retry features's delay value should
+    # be "skewed" to allow the RX node to receive 1 transmission at a time.
+    # So, use varying delay between retry attempts and 15 (at most) retry attempts
+    radio.setRetries(((node_number * 3) % 12) + 3, 15); # maximum value is 15 for both args
+
     radio.stopListening()  # put radio in TX mode
     # set the TX address to the address of the base station.
     radio.openWritingPipe(addresses[node_number])
@@ -89,7 +94,7 @@ def master(node_number):
         else:
             failures += 1
             print("failed or timed out")
-        time.sleep(0.5)  # slow down the test for readability
+        time.sleep(1)  # slow down the test for readability
     print(failures, "failures detected. Leaving TX role.")
 
 
@@ -124,7 +129,7 @@ def slave(timeout=10):
             )
             start_timer = time.monotonic()  # reset timer with every payload
 
-    print("Nothing received in 6 seconds. Leaving RX role")
+    print("Nothing received in", timeout, "seconds. Leaving RX role")
     radio.stopListening()
 
 

--- a/examples_linux/streaming_data.py
+++ b/examples_linux/streaming_data.py
@@ -120,6 +120,7 @@ def slave(timeout=6):
             print("Received: {} - {}".format(receive_payload, count))
             start_timer = time.monotonic()  # reset timer on every RX payload
 
+    print("Nothing received in", timeout, "seconds. Leaving RX role")
     # recommended behavior is to keep in TX mode while idle
     radio.stopListening()  # put the radio in TX mode
 

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/nRF24/RF24.git"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "frameworks": "arduino",
   "platforms": [
     "atmelavr",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RF24
-version=1.4.0
+version=1.4.1
 author=TMRh20
 maintainer=TMRh20,Avamander
 sentence=Radio driver, OSI layer 2 library for nrf24L01(+) modules.

--- a/utility/RPi/RF24_arch_config.h
+++ b/utility/RPi/RF24_arch_config.h
@@ -16,9 +16,11 @@
 
 #define _SPI spi
 
-#if defined SPI_HAS_TRANSACTION && !defined SPI_UART && !defined SOFTSPI
+#if defined (SPI_HAS_TRANSACTION)
+    // this gets triggered as /utility/RPi/spi.h defines SPI_HAS_TRANSACTION (unless modified by end-user)
     #define RF24_SPI_TRANSACTIONS
 #endif
+
 // GCC a Arduino Missing
 #define _BV(x) (1<<(x))
 #define pgm_read_word(p) (*(p))
@@ -39,7 +41,7 @@
 #endif
 
 #define digitalWrite(pin, value) bcm2835_gpio_write(pin, value)
-#define pinMode(pin, value) bcm2835_gpio_fsel(pin,value)
+#define pinMode(pin, value) bcm2835_gpio_fsel(pin, value)
 #define OUTPUT BCM2835_GPIO_FSEL_OUTP
 #define INPUT BCM2835_GPIO_FSEL_INPT
 #endif


### PR DESCRIPTION
~I missed a define that was supposed to be removed when testing the overload-begin() branch.~
EDIT: see https://github.com/nRF24/RF24/pull/771#pullrequestreview-673748544 comment below

Thanks to @bifferos for noticing this in #770 