### PR TITLE
Patch for #834

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -93,7 +93,7 @@ jobs:
           ./build
       
       - name: provide pigpio
-        if: ${{ matrix.config-options != '--driver=MRAA' }}
+        if: ${{ matrix.config-options != '--driver=pigpio' }}
         run: |
           git clone https://github.com/joan2937/pigpio.git
           cd pigpio

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -93,7 +93,7 @@ jobs:
           ./build
       
       - name: provide pigpio
-        if: ${{ matrix.config-options == '--driver=pigpio' }}
+        if: ${{ matrix.config-options == '--driver=pigpio' || endsWith(matrix.config-options, '--driver=RPi') }}
         run: |
           git clone https://github.com/joan2937/pigpio.git
           cd pigpio

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -93,7 +93,7 @@ jobs:
           ./build
       
       - name: provide pigpio
-        if: ${{ matrix.config-options != '--driver=pigpio' }}
+        if: ${{ matrix.config-options == '--driver=pigpio' }}
         run: |
           git clone https://github.com/joan2937/pigpio.git
           cd pigpio

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,15 @@ OBJECTS=RF24.o
 ifeq ($(DRIVER), MRAA)
 OBJECTS+=spi.o gpio.o compatibility.o
 else ifeq ($(DRIVER), RPi)
-OBJECTS+=spi.o bcm2835.o interrupt.o compatibility.o
+OBJECTS+=spi.o bcm2835.o compatibility.o
+ifneq (,$(findstring -lpigpio,$(SHARED_LINKER_LIBS)))
+OBJECTS+=interrupt.o
+endif
 else ifeq ($(DRIVER), SPIDEV)
-OBJECTS+=spi.o gpio.o compatibility.o interrupt.o
+OBJECTS+=spi.o gpio.o compatibility.o
+ifneq (,$(findstring -lpigpio,$(SHARED_LINKER_LIBS)))
+OBJECTS+=interrupt.o
+endif
 else ifeq ($(DRIVER), wiringPi)
 OBJECTS+=spi.o
 else ifeq ($(DRIVER), pigpio)

--- a/configure
+++ b/configure
@@ -428,7 +428,11 @@ LittleWire)
     SHARED_LINKER_LIBS+=" -llittlewire-spi"
     ;;
 pigpio)
-    SHARED_LINKER_LIBS+=" -lpigpio"
+    if [ $pigpio_detected -eq 0 ]; then
+        die "[ERROR] pigpio was not detected. Make sure pigpio is installed." 2
+    else
+        SHARED_LINKER_LIBS+=" -lpigpio"
+    fi
     ;;
 *)
     die "Unsupported DRIVER: ${DRIVER}." 2

--- a/configure
+++ b/configure
@@ -58,7 +58,8 @@ function execute_check {
     fi
 }
 
-if [[ $(execute_check "file /usr/lib/libpigpio.so") ]]; then
+if [[ -f "/usr/lib/libpigpio.so" || -f "/usr/local/lib/libpigpio.so" || -f "/usr/arm-linux-gnueabihf/lib/libpigpio.so" ]]; then
+    echo "[INFO] pigpio lib found."
     pigpio_detected=1
 fi
 

--- a/configure
+++ b/configure
@@ -413,12 +413,16 @@ SPIDEV)
     if [ $pigpio_detected -eq 1 ]; then
         echo "[INFO] linking to pigpio for interrupt compatibility"
         SHARED_LINKER_LIBS+=" -lpigpio"
+    else
+        CFLAGS+=" -DRF24_NO_INTERRUPT"
     fi
     ;;
 RPi)
     if [ $pigpio_detected -eq 1 ]; then
         echo "[INFO] linking to pigpio for interrupt compatibility"
         SHARED_LINKER_LIBS+=" -lpigpio"
+    else
+        CFLAGS+=" -DRF24_NO_INTERRUPT"
     fi
     ;;
 MRAA)

--- a/docs/linux_install.md
+++ b/docs/linux_install.md
@@ -7,13 +7,17 @@ Generic Linux devices are supported via SPIDEV, MRAA, RPi native via BCM2835, or
 
 @warning The manual install instructions are beginning to age because they were designed with the assumption that
 the arm-linux-gnueabihf-g\*\* compilers were available and default for the system. If you have problems
-using those instructions, please try the [instructions using CMake](md_docs_using_cmake.html).
+using the manual install instructions (especially on a 64-bit OS), please try the
+[instructions using CMake](md_docs_using_cmake.html).
+
+@note Since wiringPi is no longer maintained or distributed (as of RPi OS 11 bullseye),
+pigpio is now required for using the radio's IRQ pin. This applies to RPi, SPIDEV, and pigpio drivers. The MRAA driver may provide its own IRQ implementation. Remember that the RPi OS lite variant does not ship with pigpio installed.
 
 ## Automated Install
 
 **Designed & Tested on RPi** - Defaults to SPIDEV on devices supporting it
 
-1. Install prerequisites if there are any (MRAA, LittleWire libraries, setup SPI device etc)
+1. Install prerequisites if there are any (pigpio, MRAA, LittleWire libraries, setup SPI device etc)
 2. Download the install.sh file from [https://github.com/nRF24/.github/blob/main/installer/install.sh](https://raw.githubusercontent.com/nRF24/.github/main/installer/install.sh)
    ```shell
    wget https://raw.githubusercontent.com/nRF24/.github/main/installer/install.sh
@@ -39,7 +43,7 @@ using those instructions, please try the [instructions using CMake](md_docs_usin
 
 ## Manual Install
 
-1. Install prerequisites if there are any (MRAA, LittleWire libraries, setup SPI device etc)
+1. Install prerequisites if there are any (pigpio, MRAA, LittleWire libraries, setup SPI device etc)
    @note See the [MRAA](http://iotdk.intel.com/docs/master/mraa/index.html) documentation for more info on installing MRAA
 2. Make a directory to contain the RF24 and possibly RF24Network lib and enter it
    ```shell

--- a/docs/using_cmake.md
+++ b/docs/using_cmake.md
@@ -20,6 +20,9 @@ sudo rm /usr/local/lib/librf24-bcm.so
 sudo rm -r /usr/local/include/RF24
 ```
 
+@note Since wiringPi is no longer maintained or distributed (as of RPi OS 11 bullseye),
+pigpio is now required for using the radio's IRQ pin. This applies to RPi, SPIDEV, and pigpio drivers. The MRAA driver may provide its own IRQ implementation. Remember that the RPi OS lite variant does not ship with pigpio installed.
+
 The _librf24-bcm.so_ file may not exist if you used CMake to install the library.
 
 1. Download the appropriate package for your machine

--- a/examples_linux/Makefile
+++ b/examples_linux/Makefile
@@ -18,6 +18,9 @@ endif
 include ../Makefile.inc
 
 # define all programs
-PROGRAMS = gettingstarted acknowledgementPayloads manualAcknowledgements streamingData multiceiverDemo scanner interruptConfigure
+PROGRAMS = gettingstarted acknowledgementPayloads manualAcknowledgements streamingData multiceiverDemo scanner
+ifneq (,$(findstring -lpigpio,$(SHARED_LINKER_LIBS)))
+PROGRAMS+=interruptConfigure
+endif
 
 include Makefile.examples


### PR DESCRIPTION
solves #834

Using the RPi OS lite image doesn't ship with pigpio, and the configure script wasn't properly detecting if pigpio is installed.

- adjust configure script to check for pigpio in
   1. user installed location (when fetched from git src - typically in /usr/local/lib)
   2. apt installed location (typically in /usr/lib)
   3. and /usr/arm-linux-gnueabihf (for 32bit cross-compiling purposes)
- adjust Makefile for lib and linux examples
- augment install docs with info about pigpio as req for IRQ (and remind reader that RPi OS lite doesn't come with pigpio).

I tested this with the Linux CI: When using the SPIDEV driver (with the configure script), pigpio is no longer installed.