### PR TITLE
respect latest sphinx theme ext refactoring

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -47,7 +47,7 @@ extensions = [
     "breathe",
     "sphinx_immaterial",
     "sphinx.ext.autosectionlabel",
-    "sphinx_immaterial.cppreference",
+    "sphinx_immaterial.apidoc.cpp.cppreference",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
A slight refactor in latest sphinx-immaterial theme release requires a change in the specified extensions. Specifically the extension that automatically links certain datatypes (like `uint8_t`) to cppreferences,com.