### PR TITLE
make utilities/CMakeLists.txt respect RF24_NO_IRQ

### DIFF
--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -25,7 +25,7 @@ elseif("${RF24_DRIVER}" STREQUAL "RPi") # use RPi
             ${RF24_DRIVER}/RF24_arch_config.h
         DESTINATION include/RF24/utility/${RF24_DRIVER}
     )
-    if(NOT "${LibPIGPIO}" STREQUAL "LibPIGPIO-NOTFOUND")
+    if(NOT "${LibPIGPIO}" STREQUAL "LibPIGPIO-NOTFOUND" AND NOT DEFINED RF24_NO_INTERRUPT)
         set(RF24_LINKED_DRIVER ${LibPIGPIO} PARENT_SCOPE)
         message(STATUS "linking to pigpio lib for interrupt functionality")
         install(FILES
@@ -63,7 +63,7 @@ elseif("${RF24_DRIVER}" STREQUAL "SPIDEV") # use SPIDEV
             ${RF24_DRIVER}/RF24_arch_config.h
         DESTINATION include/RF24/utility/${RF24_DRIVER}
     )
-    if(NOT "${LibPIGPIO}" STREQUAL "LibPIGPIO-NOTFOUND")
+    if(NOT "${LibPIGPIO}" STREQUAL "LibPIGPIO-NOTFOUND" AND NOT DEFINED RF24_NO_INTERRUPT)
         set(RF24_LINKED_DRIVER ${LibPIGPIO} PARENT_SCOPE)
         message(STATUS "linking to pigpio lib for interrupt functionality")
         install(FILES


### PR DESCRIPTION
This is needed to update the pyRF24 pkg to use latest master.

This should not negatively affect RF24 lib builds because RF24_NO_INTERRUPT is respected in the root CMakeLists.txt. But, the pyRF24 pkg doesn't actually use the root CMakeLists.txt. Instead, the pyRF24 pkg only uses utility/CMakeLists.txt to get the appropriate driver sources/includes/etc.

This is the CMake equivalent of #839 which did the same exclusion of interrupt.h when it wasn't needed.