### PR TITLE
Fix `pgm_read_ptr()`: 'const void*' is not a pointer-to-object type

### DIFF
--- a/RF24_config.h
+++ b/RF24_config.h
@@ -163,7 +163,7 @@ extern HardwareSPI SPI;
         #include <pgmspace.h>
         #define PRIPSTR "%s"
         #ifndef pgm_read_ptr
-            #define pgm_read_ptr(p) (*(p))
+            #define pgm_read_ptr(p) (*(void* const*)(p))
         #endif
     #elif defined(ARDUINO) && !defined(ESP_PLATFORM) && !defined(__arm__) && !defined(__ARDUINO_X86__) || defined(XMEGA)
         #include <avr/pgmspace.h>
@@ -208,7 +208,7 @@ typedef uint16_t prog_uint16_t;
             #define pgm_read_word(p) (*(p))
         #endif
         #if !defined pgm_read_ptr || defined ARDUINO_ARCH_MBED
-            #define pgm_read_ptr(p) (*(p))
+            #define pgm_read_ptr(p) (*(void* const*)(p))
         #endif
         #ifndef PRIPSTR
             #define PRIPSTR "%s"

--- a/utility/LittleWire/RF24_arch_config.h
+++ b/utility/LittleWire/RF24_arch_config.h
@@ -18,7 +18,7 @@ extern LittleWireSPI _SPI;
 #define _BV(x)           (1 << (x))
 #define pgm_read_word(p) (*(p))
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;
 #define PSTR(x)  (x)

--- a/utility/MRAA/RF24_arch_config.h
+++ b/utility/MRAA/RF24_arch_config.h
@@ -24,7 +24,7 @@
 #define _BV(x)           (1 << (x))
 #define pgm_read_word(p) (*(p))
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 #define _SPI             spi
 
 #define RF24_LINUX

--- a/utility/RPi/RF24_arch_config.h
+++ b/utility/RPi/RF24_arch_config.h
@@ -25,7 +25,7 @@
 #define _BV(x)           (1 << (x))
 #define pgm_read_word(p) (*(p))
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;
 #define PSTR(x)  (x)

--- a/utility/SPIDEV/RF24_arch_config.h
+++ b/utility/SPIDEV/RF24_arch_config.h
@@ -51,7 +51,7 @@ typedef uint16_t prog_uint16_t;
 #define pgm_read_word(p) (*(p))
 #define PRIPSTR          "%s"
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/pigpio/RF24_arch_config.h
+++ b/utility/pigpio/RF24_arch_config.h
@@ -56,7 +56,7 @@ typedef uint16_t prog_uint16_t;
 #define pgm_read_word(p) (*(p))
 #define PRIPSTR          "%s"
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/rp2/RF24_arch_config.h
+++ b/utility/rp2/RF24_arch_config.h
@@ -45,7 +45,7 @@ typedef uint16_t prog_uint16_t;
 #define PRIPSTR          "%s"
 #define pgm_read_byte(p) (*(p))
 
-#define pgm_read_ptr(p) (*(p))
+#define pgm_read_ptr(p) (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/wiringPi/RF24_arch_config.h
+++ b/utility/wiringPi/RF24_arch_config.h
@@ -46,6 +46,6 @@ typedef uint16_t prog_uint16_t;
 #define pgm_read_word(p) (*(p))
 #define PRIPSTR          "%s"
 #define pgm_read_byte(p) (*(p))
-#define pgm_read_ptr(p)  (*(p))
+#define pgm_read_ptr(p)  (*(void* const*)(p))
 
 #endif // RF24_UTILITY_WIRINGPI_RF24_ARCH_CONFIG_H_


### PR DESCRIPTION
Calling this macro caused the following error:

> 'const void*' is not a pointer-to-object type

Similar macros, like `pgm_read_word()` and `pgm_read_byte()` are also incorrect; I can open a second PR for them if you need.

Fixes https://github.com/bblanchon/ArduinoJson/issues/1790