### PR TITLE
adjust writeFast docs

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1349,7 +1349,7 @@ bool RF24::writeFast(const void* buf, uint8_t len, const bool multicast)
     while ((get_status() & (_BV(TX_FULL)))) {
         if (status & _BV(MAX_RT)) {
             return 0; //Return 0. The previous payload has not been retransmitted
-            // From the user perspective, if you get a 0, just keep trying to send the same payload
+            // From the user perspective, if you get a 0, call txStandBy()
         }
 #if defined(FAILURE_HANDLING) || defined(RF24_LINUX)
         if (millis() - timer > 95) {


### PR DESCRIPTION
Also amends an outdated comment in the definition.

New doc output:
![image](https://user-images.githubusercontent.com/14963867/187807037-b5abf83c-4047-470d-98ea-d841e873aeb6.png)


Related to user experience described in #865 