### PR TITLE
Fix `pgm_read_byte/word()` definitions

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -30,7 +30,7 @@ jobs:
       #   with:
       #     version: 12
       - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
+        run: python3 -m pip install cpp-linter
       - name: run linter as a python package
         id: linter
         run: |
@@ -138,6 +138,15 @@ jobs:
           fqbn: ${{ matrix.fqbn }}
           enable-deltas-report: ${{ matrix.enable-deltas-report }}
           sketches-report-path: ${{ env.SKETCHES_REPORTS }}
+          # install earlphilhower's arduino-pico platform index
+          platforms: |
+            - name: rp2040:rp2040
+              source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+            - name: arduino:avr
+            - name: arduino:megaavr
+            - name: arduino:sam
+            - name: arduino:samd
+            - name: arduino:mbed
       
       # This step is needed to pass the size data to the report job 
       - name: Upload sketches report to workflow artifact

--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -78,6 +78,10 @@ jobs:
           - "arduino:avr:one"
           - "arduino:avr:unowifi"
           - "arduino:mbed:nano33ble"
+          - "arduino:mbed:nanorp2040connect"
+          - "rp2040:rp2040:rpipico"
+          - "rp2040:rp2040:rpipicow"
+          - "rp2040:rp2040:adafruit_feather"
           - "arduino:samd:mkr1000"  # InterruptConfigure.ino uses pin 2
           - "arduino:samd:mkrwifi1010"  # InterruptConfigure.ino uses pin 2
           - "arduino:samd:nano_33_iot"

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -65,7 +65,7 @@ jobs:
       #   with:
       #     version: 12
       - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
+        run: python3 -m pip install cpp-linter
       - name: run linter as a python package
         id: linter
         run: |

--- a/.github/workflows/build_platformIO.yml
+++ b/.github/workflows/build_platformIO.yml
@@ -112,6 +112,8 @@ jobs:
           - "teensy40"
           - "teensy41"
           - "teensylc"
+          - "genericSTM32F411CE"
+          - "blackpill_f103c8"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_platformIO.yml
+++ b/.github/workflows/build_platformIO.yml
@@ -74,7 +74,7 @@ jobs:
       #   with:
       #     version: 12
       - name: Install linter python package
-        run: python3 -m pip install git+https://github.com/cpp-linter/cpp-linter-action@v1
+        run: python3 -m pip install cpp-linter
       - name: run linter as a python package
         id: linter
         run: |

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -205,7 +205,7 @@ typedef uint16_t prog_uint16_t;
             #define PROGMEM
         #endif
         #ifndef pgm_read_word
-            #define pgm_read_word(p) (*(p))
+            #define pgm_read_word(p) (*(const unsigned short *)(addr))
         #endif
         #if !defined pgm_read_ptr || defined ARDUINO_ARCH_MBED
             #define pgm_read_ptr(p) (*(void* const*)(p))

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -205,7 +205,7 @@ typedef uint16_t prog_uint16_t;
             #define PROGMEM
         #endif
         #ifndef pgm_read_word
-            #define pgm_read_word(p) (*(const unsigned short *)(addr))
+            #define pgm_read_word(p) (*(const unsigned short*)(p))
         #endif
         #if !defined pgm_read_ptr || defined ARDUINO_ARCH_MBED
             #define pgm_read_ptr(p) (*(void* const*)(p))

--- a/utility/ATXMegaD3/RF24_arch_config.h
+++ b/utility/ATXMegaD3/RF24_arch_config.h
@@ -53,9 +53,9 @@ typedef uint16_t prog_uint16_t;
 //#define printf_P printf
 //#define strlen_P strlen
 //#define PROGMEM
-//#define pgm_read_word(p) (*(p))
+//#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR "%s"
-//#define pgm_read_byte(p) (*(p))
+//#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/ATXMegaD3/RF24_arch_config.h
+++ b/utility/ATXMegaD3/RF24_arch_config.h
@@ -53,9 +53,9 @@ typedef uint16_t prog_uint16_t;
 //#define printf_P printf
 //#define strlen_P strlen
 //#define PROGMEM
-//#define pgm_read_word(p) (*(const unsigned short *)(addr))
+//#define pgm_read_word(p) (*(const unsigned short *)(p))
 #define PRIPSTR "%s"
-//#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+//#define pgm_read_byte(p) (*(const unsigned char *)(p))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/LittleWire/RF24_arch_config.h
+++ b/utility/LittleWire/RF24_arch_config.h
@@ -16,8 +16,8 @@ extern LittleWireSPI _SPI;
 
 // GCC a Arduino Missing
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;

--- a/utility/LittleWire/RF24_arch_config.h
+++ b/utility/LittleWire/RF24_arch_config.h
@@ -16,8 +16,8 @@ extern LittleWireSPI _SPI;
 
 // GCC a Arduino Missing
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(p))
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;

--- a/utility/MRAA/RF24_arch_config.h
+++ b/utility/MRAA/RF24_arch_config.h
@@ -22,8 +22,8 @@
 #define HIGH             1
 #define LOW              0
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(p))
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 #define _SPI             spi
 

--- a/utility/MRAA/RF24_arch_config.h
+++ b/utility/MRAA/RF24_arch_config.h
@@ -22,8 +22,8 @@
 #define HIGH             1
 #define LOW              0
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 #define _SPI             spi
 

--- a/utility/RPi/RF24_arch_config.h
+++ b/utility/RPi/RF24_arch_config.h
@@ -23,8 +23,8 @@
 
 // GCC a Arduino Missing
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;

--- a/utility/RPi/RF24_arch_config.h
+++ b/utility/RPi/RF24_arch_config.h
@@ -23,8 +23,8 @@
 
 // GCC a Arduino Missing
 #define _BV(x)           (1 << (x))
-#define pgm_read_word(p) (*(p))
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 //typedef uint16_t prog_uint16_t;

--- a/utility/SPIDEV/RF24_arch_config.h
+++ b/utility/SPIDEV/RF24_arch_config.h
@@ -48,9 +48,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino

--- a/utility/SPIDEV/RF24_arch_config.h
+++ b/utility/SPIDEV/RF24_arch_config.h
@@ -48,9 +48,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino

--- a/utility/Template/RF24_arch_config.h
+++ b/utility/Template/RF24_arch_config.h
@@ -56,9 +56,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/Template/RF24_arch_config.h
+++ b/utility/Template/RF24_arch_config.h
@@ -56,9 +56,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 
 // Function, constant map as a result of migrating from Arduino
 #define LOW                      GPIO::OUTPUT_LOW

--- a/utility/pigpio/RF24_arch_config.h
+++ b/utility/pigpio/RF24_arch_config.h
@@ -53,9 +53,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino

--- a/utility/pigpio/RF24_arch_config.h
+++ b/utility/pigpio/RF24_arch_config.h
@@ -53,9 +53,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 // Function, constant map as a result of migrating from Arduino

--- a/utility/rp2/RF24_arch_config.h
+++ b/utility/rp2/RF24_arch_config.h
@@ -41,9 +41,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 
 #define pgm_read_ptr(p) (*(void* const*)(p))
 

--- a/utility/rp2/RF24_arch_config.h
+++ b/utility/rp2/RF24_arch_config.h
@@ -41,9 +41,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 
 #define pgm_read_ptr(p) (*(void* const*)(p))
 

--- a/utility/wiringPi/RF24_arch_config.h
+++ b/utility/wiringPi/RF24_arch_config.h
@@ -43,9 +43,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(const unsigned short *)(addr))
+#define pgm_read_word(p) (*(const unsigned short*)(p))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(const unsigned char *)(addr))
+#define pgm_read_byte(p) (*(const unsigned char*)(p))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 #endif // RF24_UTILITY_WIRINGPI_RF24_ARCH_CONFIG_H_

--- a/utility/wiringPi/RF24_arch_config.h
+++ b/utility/wiringPi/RF24_arch_config.h
@@ -43,9 +43,9 @@ typedef uint16_t prog_uint16_t;
 #define printf_P printf
 #define strlen_P strlen
 #define PROGMEM
-#define pgm_read_word(p) (*(p))
+#define pgm_read_word(p) (*(const unsigned short *)(addr))
 #define PRIPSTR          "%s"
-#define pgm_read_byte(p) (*(p))
+#define pgm_read_byte(p) (*(const unsigned char *)(addr))
 #define pgm_read_ptr(p)  (*(void* const*)(p))
 
 #endif // RF24_UTILITY_WIRINGPI_RF24_ARCH_CONFIG_H_


### PR DESCRIPTION
Corresponding to https://github.com/nRF24/RF24/pull/864, this completes compliance with the unified ArduinoCore-API about 

- `pgm_read_word()`
- `pgm_read_byte()`

see https://github.com/arduino/ArduinoCore-API/blob/e26862e453c1234e1c23506d1839bfa68999d911/api/deprecated-avr-comp/avr/pgmspace.h#L102-L103
###  Platforms to test
- [x] Pico SDK
- [x] SPIDEV
- [x] RPi
- [x] MRAA
- [ ] wiringPi
- [x] pigpio

## CI changes
- adds RP2040 boards to Arduino CI, namely
    - RPi pico
    - RPi pico W
    - Adafruit Feather RP2040
    - Arduino Nano Connect (RP2040)
- adds STM32 boards to PlatformIO CI, namely
    - STM32F103C8 (blue pill)
    - STM32F411CE (black pill)
- installs cpp-linter pkg from PyPI instead of building it from github source

---
Special thanks to @bblanchon for bringing this to our attention and providing a comprehensive list of affected cores.