### PR TITLE
add printf support to ESP32/8266 and arduino-pico cores

### DIFF
--- a/.github/workflows/build_platformIO.yml
+++ b/.github/workflows/build_platformIO.yml
@@ -114,6 +114,8 @@ jobs:
           - "teensylc"
           - "genericSTM32F411CE"
           - "blackpill_f103c8"
+          - "nodemcuv2"
+          - "adafruit_qtpy_esp32s2"
 
     steps:
     - uses: actions/checkout@v2

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -159,12 +159,18 @@ extern HardwareSPI SPI;
     #endif // defined (__ARDUINO_X86__)
 
     // Progmem is Arduino-specific
-    #if defined(ARDUINO_ARCH_ESP8266) || defined(ESP32)
+    #if defined(ARDUINO_ARCH_ESP8266) || defined(ESP32) || (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED))
         #include <pgmspace.h>
         #define PRIPSTR "%s"
         #ifndef pgm_read_ptr
             #define pgm_read_ptr(p) (*(void* const*)(p))
         #endif
+        // Serial.printf() is no longer defined in the unifying Arduino/ArduinoCore-API repo
+        // Serial.printf() is defined if using the arduino-pico/esp32/8266 repo
+        #if defined(ARDUINO_ARCH_ESP32) // do not `undef` when using the espressif SDK only
+            #undef printf_P             // needed for ESP32 core
+        #endif
+        #define printf_P Serial.printf
     #elif defined(ARDUINO) && !defined(ESP_PLATFORM) && !defined(__arm__) && !defined(__ARDUINO_X86__) || defined(XMEGA)
         #include <avr/pgmspace.h>
         #define PRIPSTR "%S"


### PR DESCRIPTION
resolves #870

I also added the 2 boards to the PlatformIO CI workflow:
1. Node MCU ESP8266 board
2. Adafruit QtPy ESP32-S2 board

This should help us detect compiler warnings and whatnot.