### PR TITLE
Update pico_sdk.md to reflect changes to SPI with user-specified pins

### DIFF
--- a/docs/pico_sdk.md
+++ b/docs/pico_sdk.md
@@ -144,6 +144,7 @@ This option is the most reliable and flexible. It involves calling `SPI.begin()`
 #include <RF24.h>
 
 RF24 radio(7, 8); // pin numbers connected to the radio's CE and CSN pins (respectively)
+SPI spi;
 
 int main()
 {


### PR DESCRIPTION
Hi,

Updated some of my code that uses the RF24 library, guess there's been some changes in the meantime as the previous code no longer compiles. Quick look suggests now the SPI needs be declared seperately and cannot be reference just by importing RF24 and using spi.begin

Previous code:
```
    spi.begin(spi_bus, sck_pin, tx_pin, rx_pin);

    if(radio.begin(&spi, ce_pin, csn_pin) == false) {     // Setup and configure rf radio
        return(false);
    }
```

Seems to be fixed by declaring a SPI object outside the function that initialises the radio. (could be a better way to do this?)

`SPI spi;`

Hence have suggested a change to documentation to reflect this.
