### PR TITLE
Linux chip enable conditional statement

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -102,10 +102,14 @@ void RF24::csn(bool mode)
 
 void RF24::ce(bool level)
 {
+#ifndef RF24_LINUX
     //Allow for 3-pin use on ATTiny
     if (ce_pin != csn_pin) {
+#endif
         digitalWrite(ce_pin, level);
+#ifndef RF24_LINUX
     }
+#endif
 }
 
 /****************************************************************************/


### PR DESCRIPTION
Issue: RF24 radio(10, 10, 1000000) 
OrangePi Zero with GPIO10 as chip enable. OrangePi Zero uses spidev1.0 because spidev0.0 is used for flash. Then if statement is true and does not enable TX on nRF module. Conditional statement fixes this issue; The gettingstarted.cpp program works now with the modification

See [https://github.com/nRF24/RF24/issues/903](url) for the discussion