### PR TITLE
Add delay to manualAcknowledgements example

### DIFF
--- a/examples/ManualAcknowledgements/ManualAcknowledgements.ino
+++ b/examples/ManualAcknowledgements/ManualAcknowledgements.ino
@@ -129,6 +129,7 @@ void loop() {
       while (!radio.available()) {             // wait for response
         if (millis() - start_timeout > 200)    // only wait 200 ms
           break;
+        delayMicroseconds(200);                // relax probing of available()
       }
       unsigned long end_timer = micros();  // end the timer
       radio.stopListening();               // put back in TX mode

--- a/examples/ManualAcknowledgements/ManualAcknowledgements.ino
+++ b/examples/ManualAcknowledgements/ManualAcknowledgements.ino
@@ -129,7 +129,7 @@ void loop() {
       while (!radio.available()) {             // wait for response
         if (millis() - start_timeout > 200)    // only wait 200 ms
           break;
-        delayMicroseconds(200);                // relax probing of available()
+        delayMicroseconds(200);  // relax probing of available()
       }
       unsigned long end_timer = micros();  // end the timer
       radio.stopListening();               // put back in TX mode


### PR DESCRIPTION
Closes #949
- Add delay to relax how often available() is called to let the radio internally do its thing
- Thanks to @pfpp89 for discovering, reporting & testing this issue