### PR TITLE
Link to new (CMake) installer by default

### DIFF
--- a/docs/linux_install.md
+++ b/docs/linux_install.md
@@ -3,19 +3,62 @@
 @tableofcontents
 
 <!-- markdownlint-disable MD031 -->
-Generic Linux devices are supported via SPIDEV, MRAA, RPi native via BCM2835, or using LittleWire.
+Generic Linux devices are supported via SPIDEV, PiGPIO, MRAA, RPi native via BCM2835, or using LittleWire.
 
 @note The SPIDEV option should work with most Linux systems supporting spi userspace device.
-
-@warning These install instructions are beginning to age because they were designed with the assumption that
-the arm-linux-gnueabihf-g\*\* compilers were available and default for the system. If you have problems
-using the manual install instructions (especially on a 64-bit OS), please try the
-[instructions using CMake](md_docs_using_cmake.html).
 
 @note Since wiringPi is no longer maintained or distributed (as of RPi OS 11 bullseye),
 pigpio is now required for using the radio's IRQ pin. This applies to RPi, SPIDEV, and pigpio drivers. The MRAA driver may provide its own IRQ implementation. Remember that the RPi OS lite variant does not ship with pigpio installed.
 
-## Automated Install
+
+### Automatic Installation (New)
+
+Using CMake: (See the [instructions using CMake](md_docs_using_cmake.html) for more information and options)
+
+1. Download the install.sh file from [https://github.com/nRF24/.github/blob/main/installer/install.sh](https://github.com/nRF24/.github/blob/main/installer/install.sh)
+   ```shell
+   wget https://raw.githubusercontent.com/nRF24/.github/main/installer/install.sh
+   ```
+2. Make it executable
+   ```shell
+   chmod +x install.sh
+   ```
+3. Run it and choose your options
+   ```shell
+   ./install.sh
+   ```
+   The script will detect needed dependencies and install what it needs according to the user input.
+
+   It will also ask to install a python package named [pyRF24](https://github.com/nRF24/pyRF24).
+   This is not the same as the traditionally provided python wrappers as the pyRF24 package can be
+   used independent of the C++ installed libraries. For more information on this newer python
+   package, please check out [the pyRF24 documentation](https://nrf24.github.io/pyRF24/).
+4. Try an example from one of the libraries
+   ```shell
+   cd ~/rf24libs/RF24/examples_linux
+   ```
+
+   Edit the gettingstarted example, to set your pin configuration
+   ```shell
+   nano gettingstarted.cpp
+   ```
+
+   Build the examples. Remember to set the `RF24_DRIVER` option according to the one that was
+   selected during the scripted install.
+   ```shell
+   mkdir build && cd build
+   cmake .. -D RF24_DRIVER=SPIDEV
+   make
+   ```
+
+   Run the example
+   ```shell
+   sudo ./gettingstarted
+   ```
+
+See the [instructions using CMake](md_docs_using_cmake.html) for more information and options
+
+## Automated Install (Deprecated)
 
 **Designed & Tested on RPi** - Defaults to SPIDEV on devices supporting it
 
@@ -43,7 +86,7 @@ pigpio is now required for using the radio's IRQ pin. This applies to RPi, SPIDE
    sudo ./gettingstarted
    ```
 
-## Manual Install
+## Manual Install (Deprecated)
 
 1. Install prerequisites if there are any (pigpio, MRAA, LittleWire libraries, setup SPI device etc)
    @note See the [MRAA](http://iotdk.intel.com/docs/master/mraa/index.html) documentation for more info on installing MRAA
@@ -86,7 +129,7 @@ pigpio is now required for using the radio's IRQ pin. This applies to RPi, SPIDE
    sudo ./gettingstarted
    ```
 
-### Build using SPIDEV
+### Build using SPIDEV (Deprecated)
 
 1. Make sure that spi device support is enabled and /dev/spidev\<a\>.\<b\> is present
 2. Manual Install using SPIDEV:


### PR DESCRIPTION
- Point to new CMake installer by default
- Mark old installer deprecated

I think this change will make things easier for users, since the CMake installer works on every RPi version.
I've marked the old installer 'Deprecated' as well