### PR TITLE
Update SPIDEV driver for Character Device v2 ABI; cache FDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,13 @@ if(DEFINED RF24_SPI_SPEED)
         RF24_SPI_SPEED=${RF24_SPI_SPEED}
     )
 endif()
+# allow user customization of default GPIO chip used with the SPIDEV driver
+if(DEFINED RF24_SPIDEV_GPIO_CHIP)
+    message(STATUS "RF24_SPIDEV_GPIO_CHIP set to ${RF24_SPIDEV_GPIO_CHIP}")
+    target_compile_definitions(${LibTargetName} PUBLIC
+        RF24_SPIDEV_GPIO_CHIP="${RF24_SPIDEV_GPIO_CHIP}"
+    )
+endif()
 # conditionally disable interruot support (a pigpio specific feature)
 if("${LibPIGPIO}" STREQUAL "LibPIGPIO-NOTFOUND" OR DEFINED RF24_NO_INTERRUPT)
     message(STATUS "Disabling IRQ pin support")

--- a/utility/SPIDEV/RF24_arch_config.h
+++ b/utility/SPIDEV/RF24_arch_config.h
@@ -44,8 +44,6 @@
 #endif
 
 typedef uint16_t prog_uint16_t;
-typedef uint16_t rf24_gpio_pin_t;
-#define RF24_PIN_INVALID 0xFFFF
 
 #define PSTR(x)  (x)
 #define printf_P printf

--- a/utility/SPIDEV/gpio.cpp
+++ b/utility/SPIDEV/gpio.cpp
@@ -36,6 +36,8 @@ struct GlobalCache
             if (fd < 0) {
                 std::string msg = "Can't open device ";
                 msg += chip;
+                msg += "; ";
+                msg += strerror(errno);
                 throw GPIOException(msg);
             }
         }

--- a/utility/SPIDEV/gpio.cpp
+++ b/utility/SPIDEV/gpio.cpp
@@ -6,14 +6,63 @@
  *
  */
 #include <linux/gpio.h>
-#include "gpio.h"
 #include <unistd.h>    // close()
 #include <fcntl.h>     // open()
 #include <sys/ioctl.h> // ioctl()
-#include <errno.h>     // errno
-#include <string.h>    // memset()
+#include <errno.h>     // errno, strerror()
+#include <string.h>    // std::string, strcpy()
+#include <map>
+#include "gpio.h"
 
-const char* dev_name = "/dev/gpiochip4";
+// instantiate some global structs to setup cache
+// doing this globally ensures the data struct is zero-ed out
+typedef int gpio_fd; // for readability
+std::map<rf24_gpio_pin_t, gpio_fd> cached_pins;
+struct gpio_v2_line_request request;
+struct gpio_v2_line_values data;
+
+// use this struct to keep a track of open file descriptors
+struct GlobalCache
+{
+    const char* chip = "/dev/gpiochip4";
+    int fd = -1;
+
+    // should be called automatically on program start.
+    // Here, we do some one-off configuration.
+    GlobalCache()
+    {
+        if (fd < 0) {
+            fd = ::open(chip, O_RDWR);
+            if (fd < 0) {
+                chip = "/dev/gpiochip0";
+                fd = ::open(chip, O_RDWR);
+                if (fd < 0) {
+                    std::string msg = "Can't open device ";
+                    msg += chip;
+                    throw GPIOException(msg);
+                }
+            }
+        }
+        request.num_lines = 1;
+        strcpy(request.consumer, "RF24 lib");
+        data.mask = 1ULL; // only change value for specified pin
+    }
+
+    // Should be called automatically on program exit.
+    // What we need here is to make sure that the File Descriptors used to
+    // control GPIO pins are properly closed.
+    ~GlobalCache()
+    {
+        if (fd >= 0) {
+            close(fd);
+        }
+        for (std::map<rf24_gpio_pin_t, gpio_fd>::iterator i = cached_pins.begin(); i != cached_pins.end(); ++i) {
+            if (i->second > 0) {
+                close(i->second);
+            }
+        }
+    }
+} gpio_cache;
 
 GPIO::GPIO()
 {
@@ -23,98 +72,90 @@ GPIO::~GPIO()
 {
 }
 
-void GPIO::open(int port, int DDR)
+void GPIO::open(rf24_gpio_pin_t port, int DDR)
 {
-    int fd;
-    fd = ::open(dev_name, O_RDONLY);
-    if (fd >= 0) {
-        ::close(fd);
+    // check if pin is already in use
+    std::map<rf24_gpio_pin_t, gpio_fd>::iterator pin = cached_pins.find(port);
+    if (pin == cached_pins.end()) { // pin not in use; add it to cached request
+        request.offsets[0] = port;
     }
     else {
-        dev_name = "/dev/gpiochip0";
-        fd = ::open(dev_name, O_RDONLY);
-        if (fd >= 0) {
-            ::close(fd);
-        }
-        else {
-            throw GPIOException("can't open /dev/gpiochip");
+        request.fd = pin->second;
+    }
+    // set the pin and direction
+    request.config.flags = DDR ? GPIO_V2_LINE_FLAG_OUTPUT : GPIO_V2_LINE_FLAG_INPUT;
+
+    int ret;
+    if (request.fd <= 0) {
+        ret = ioctl(gpio_cache.fd, GPIO_V2_GET_LINE_IOCTL, &request);
+        if (ret == -1 || request.fd <= 0) {
+            std::string msg = "[GPIO::open] Can't get line handle from IOCTL; ";
+            msg += strerror(errno);
+            throw GPIOException(msg);
+            return;
         }
     }
+    ret = ioctl(request.fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &request.config);
+    if (ret == -1) {
+        std::string msg = "[gpio::open] Can't set line config; ";
+        msg += strerror(errno);
+        throw GPIOException(msg);
+        return;
+    }
+    cached_pins.insert(std::pair<rf24_gpio_pin_t, gpio_fd>(port, request.fd));
 }
 
-void GPIO::close(int port)
+void GPIO::close(rf24_gpio_pin_t port)
 {
+    // This is not really used in RF24 convention (designed for embedded apps).
+    // Instead rely on gpio_cache destructor (see above)
 }
 
-int GPIO::read(int port)
+int GPIO::read(rf24_gpio_pin_t port)
 {
-    int fd = ::open(dev_name, O_RDWR);
-    if (fd < 0) {
-        throw GPIOException("Can't open character device");
+    // if (gpio_cache.fd < 0) {
+    //     throw GPIOException("[GPIO::read] device not initialized! Use GPIO::open() first.");
+    //     return -1;
+    // }
+
+    std::map<rf24_gpio_pin_t, gpio_fd>::iterator pin = cached_pins.find(port);
+    if (pin == cached_pins.end() || pin->second <= 0) {
+        throw GPIOException("[GPIO::read] pin not initialized! Use GPIO::open() first");
         return -1;
     }
 
-    struct gpio_v2_line_request rq;
-    memset(&rq, 0, sizeof(rq));
-    rq.offsets[0] = port;
-    rq.num_lines = 1;
-    rq.config.flags = GPIO_V2_LINE_FLAG_INPUT;
+    data.bits = 0ULL;
 
-    int ret = ioctl(fd, GPIO_V2_GET_LINE_IOCTL, &rq);
+    int ret = ioctl(pin->second, GPIO_V2_LINE_GET_VALUES_IOCTL, &data);
     if (ret == -1) {
-        std::string msg = "[GPIO::read] Can't get line handle from IOCTL; ";
-        msg += strerror(errno);
-        throw GPIOException(msg);
-        return ret;
-    }
-
-    struct gpio_v2_line_values data;
-    data.bits = 0;
-    data.mask = 1;
-    ret = ioctl(rq.fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &data);
-    if (ret == -1 || rq.fd <= 0) {
         std::string msg = "[GPIO::read] Can't get line value from IOCTL; ";
         msg += strerror(errno);
         throw GPIOException(msg);
         return ret;
     }
-    ::close(rq.fd);
-    ::close(fd);
-    return data.bits & data.mask;
+    return data.bits & 1ULL;
 }
 
-void GPIO::write(int port, int value)
+void GPIO::write(rf24_gpio_pin_t port, int value)
 {
-    int fd = ::open(dev_name, O_RDWR);
-    if (fd < 0) {
-        throw GPIOException("Can't open character device");
+    // if (gpio_cache.fd < 0) {
+    //     throw GPIOException("[GPIO::write] device not initialized! Use GPIO::open() first.");
+    //     return;
+    // }
+
+    std::map<rf24_gpio_pin_t, gpio_fd>::iterator pin = cached_pins.find(port);
+    if (pin == cached_pins.end() || pin->second <= 0) {
+        throw GPIOException("[GPIO::write] pin not initialized! Use GPIO::open() first");
         return;
     }
 
-    gpio_v2_line_request rq;
-    memset(&rq, 0, sizeof(rq));
-    rq.offsets[0] = port;
-    rq.num_lines = 1;
-    rq.config.flags = GPIO_V2_LINE_FLAG_OUTPUT;
+    data.bits = value;
 
-    int ret = ioctl(fd, GPIO_V2_GET_LINE_IOCTL, &rq);
+    int ret = ioctl(pin->second, GPIO_V2_LINE_SET_VALUES_IOCTL, &data);
     if (ret == -1) {
-        std::string msg = "[GPIO::write] Can't get line handle from IOCTL; ";
-        msg += strerror(errno);
-        throw GPIOException(msg);
-        return;
-    }
-
-    struct gpio_v2_line_values data;
-    data.bits |= value;
-    data.mask = 1;
-    ret = ioctl(rq.fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &data);
-    if (ret == -1 || rq.fd <= 0) {
         std::string msg = "[GPIO::write] Can't set line value from IOCTL; ";
         msg += strerror(errno);
         throw GPIOException(msg);
         return;
     }
-    ::close(rq.fd);
-    ::close(fd);
 }

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -21,6 +21,14 @@
 typedef uint16_t rf24_gpio_pin_t;
 #define RF24_PIN_INVALID 0xFFFF
 
+#ifndef RF24_SPIDEV_GPIO_CHIP
+    /**
+     * The default GPIO chip to use.  Defaults to `/dev/gpiochip4` (for RPi5).
+     * Falls back to `/dev/gpiochip0` if this value is somehow incorrect.
+     */
+    #define RF24_SPIDEV_GPIO_CHIP "/dev/gpiochip4"
+#endif
+
 /** Specific exception for SPI errors */
 class GPIOException : public std::runtime_error
 {

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -16,6 +16,11 @@
 #include <cstdio>
 #include <map>
 #include <stdexcept>
+#include <cstdint>
+
+
+typedef uint16_t rf24_gpio_pin_t;
+#define RF24_PIN_INVALID 0xFFFF
 
 /** Specific exception for SPI errors */
 class GPIOException : public std::runtime_error
@@ -41,13 +46,13 @@ public:
 
     GPIO();
 
-    static void open(int port, int DDR);
+    static void open(rf24_gpio_pin_t port, int DDR);
 
-    static void close(int port);
+    static void close(rf24_gpio_pin_t port);
 
-    static int read(int port);
+    static int read(rf24_gpio_pin_t port);
 
-    static void write(int port, int value);
+    static void write(rf24_gpio_pin_t port, int value);
 
     virtual ~GPIO();
 

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -39,7 +39,28 @@ public:
     }
 };
 
-typedef int GPIOfdCache_t;
+/// A struct to manage the GPIO chip file descriptor.
+/// This struct's destructor should close any cached GPIO pin requests' file descriptors.
+struct GPIOChipCache
+{
+    const char* chip = RF24_SPIDEV_GPIO_CHIP;
+    int fd = -1;
+
+    /// Open the File Descriptor for the GPIO chip
+    void openDevice();
+
+    /// Close the File Descriptor for the GPIO chip
+    void closeDevice();
+
+    /// should be called automatically on program start.
+    /// Here, we do some one-off configuration.
+    GPIOChipCache();
+
+    /// Should be called automatically on program exit.
+    /// What we need here is to make sure that the File Descriptors used to
+    /// control GPIO pins are properly closed.
+    ~GPIOChipCache();
+};
 
 class GPIO
 {

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -18,7 +18,6 @@
 #include <stdexcept>
 #include <cstdint>
 
-
 typedef uint16_t rf24_gpio_pin_t;
 #define RF24_PIN_INVALID 0xFFFF
 


### PR DESCRIPTION
- uses Linux Kernel's Character Device v2 ABI instead of the deprecated v1 ABI
- caches the File Descriptors used to control GPIO pins