### PR TITLE
cache gpio chip detection when properly initialized

### DIFF
--- a/utility/RPi/interrupt.cpp
+++ b/utility/RPi/interrupt.cpp
@@ -28,8 +28,10 @@ void IrqChipCache::openDevice()
             msg += "; ";
             msg += strerror(errno);
             throw IRQException(msg);
+            return;
         }
     }
+    chipInitialized = true;
 }
 
 void IrqChipCache::closeDevice()
@@ -89,6 +91,10 @@ int attachInterrupt(rf24_gpio_pin_t pin, int mode, void (*function)(void))
         irqChipCache.openDevice();
     }
     catch (IRQException& exc) {
+        if (irqChipCache.chipInitialized) {
+            throw exc;
+            return 0;
+        }
         irqChipCache.chip = "/dev/gpiochip0";
         irqChipCache.openDevice();
     }

--- a/utility/RPi/interrupt.h
+++ b/utility/RPi/interrupt.h
@@ -33,6 +33,7 @@ struct IrqChipCache
 {
     const char* chip = RF24_LINUX_GPIO_CHIP;
     int fd = -1;
+    bool chipInitialized = false;
 
     /// Open the File Descriptor for the GPIO chip
     void openDevice();

--- a/utility/SPIDEV/gpio.cpp
+++ b/utility/SPIDEV/gpio.cpp
@@ -31,8 +31,10 @@ void GPIOChipCache::openDevice()
             msg += "; ";
             msg += strerror(errno);
             throw GPIOException(msg);
+            return;
         }
     }
+    chipInitialized = true;
 }
 
 void GPIOChipCache::closeDevice()
@@ -77,6 +79,10 @@ void GPIO::open(rf24_gpio_pin_t port, int DDR)
         gpioCache.openDevice();
     }
     catch (GPIOException& exc) {
+        if (gpioCache.chipInitialized) {
+            throw exc;
+            return;
+        }
         gpioCache.chip = "/dev/gpiochip0";
         gpioCache.openDevice();
     }

--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -44,6 +44,7 @@ struct GPIOChipCache
 {
     const char* chip = RF24_LINUX_GPIO_CHIP;
     int fd = -1;
+    bool chipInitialized = false;
 
     /// Open the File Descriptor for the GPIO chip
     void openDevice();

--- a/utility/SPIDEV/interrupt.cpp
+++ b/utility/SPIDEV/interrupt.cpp
@@ -69,6 +69,10 @@ int attachInterrupt(rf24_gpio_pin_t pin, int mode, void (*function)(void))
         irqChipCache.openDevice();
     }
     catch (GPIOException& exc) {
+        if (irqChipCache.chipInitialized) {
+            throw exc;
+            return 0;
+        }
         irqChipCache.chip = "/dev/gpiochip0";
         irqChipCache.openDevice();
     }


### PR DESCRIPTION
This will prevent falling back to `/dev/gpiochip0` when `/dev/gpiochipX` was previously opened successfully.

This is designed to alert users when multiple processes are simultaneously using `/dev/gpiochipX`, but it should only happen if either
1. another process is spamming the gpiochipX.
2. the rare occurrence when RF24 needs to open gpiochipX while it is still used by another process.