### PR TITLE
Add link to RF24G library in docs

### DIFF
--- a/docs/main_page.md
+++ b/docs/main_page.md
@@ -33,6 +33,7 @@ changes.
 - [RF24Ethernet](http://nRF24.github.io/RF24Ethernet): TCP/IP Radio Mesh Networking (shares Arduino Ethernet API)
 - [RF24Audio](http://nRF24.github.io/RF24Audio): Realtime Wireless Audio streaming
 - [nrf_to_nrf](https://github.com/TMRh20/nrf_to_nrf): OSI Layer 2 radio driver for NRF52x radios. Replaces RF24 layer for new radio devices.
+- [RF24G](https://hobietime.github.io/RF24G/html/): Create a true mesh of up to 7 nrf24l01 and/or nrf52x devices
 - [TMRh20 Blog: RF24 Optimization Overview](http://tmrh20.blogspot.com/2014/03/high-speed-data-transfers-and-wireless.html)
 - [TMRh20: RPi/Linux with RF24Gateway](http://tmrh20.blogspot.com/2016/08/raspberry-pilinux-with-nrf24l01.html)
 - [All TMRh20 Documentation Main Page](http://tmrh20.github.io/)


### PR DESCRIPTION
- Recently added some changes to the RF24G lib to support nrf52x devices, and up to 7 devices in a 'true mesh' configuration where every device has a path to every other device. Kind of a neat library, clean and straightforward.
- https://github.com/Hobietime/RF24G/pull/5