### PR TITLE
wrap `wiringPiISRStop()` in driver API

### DIFF
--- a/utility/wiringPi/interrupt.h
+++ b/utility/wiringPi/interrupt.h
@@ -7,8 +7,6 @@
 #include <wiringPi.h>
 
 #define attachInterrupt wiringPiISR
-
-// wiringPi has no detachInterrupt() implementation. Therefor, we will not define it here.
-// Invoking detachInterrupt() with this wiringPi driver/wrapper should trigger compilation errors
+#define detachInterrupt wiringPiISRStop
 
 #endif // RF24_UTILITY_WIRINGPI_INTERRUPT_H__


### PR DESCRIPTION
I think I found the equivalent to `detachInterrupt()` in wiringPi lib. Its not documented, but [`wiringPiISRStop()`](https://github.com/WiringPi/WiringPi/blob/61126f0af04c2281240273b0f77f90fbedd8cf30/wiringPi/wiringPi.c#L2254-L2256) is used [in wiringPi lib's examples/tests](https://github.com/WiringPi/WiringPi/blob/master/examples/isr3.c).