### PR TITLE
Update doxygen CSS

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -40,5 +40,5 @@ jobs:
     uses: nRF24/.github/.github/workflows/build_docs.yaml@main
     with:
       deploy-gh-pages: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') }}
-      doxygen-version: '1.10.0'
+      doxygen-version: '1.11.0'
     secrets: inherit

--- a/docs/doxygen-custom.css
+++ b/docs/doxygen-custom.css
@@ -2,33 +2,74 @@ table.markdownTable th {
   color: unset;
 }
 
-/* overrides from default CSSS for some admonitions */
-dl.note, dl.remark,
-dl.warning, dl.attention {
+/* overrides from default CSS for some admonitions */
+dl.note,
+dl.remark,
+dl.warning,
+dl.attention,
+dl.important,
+dl.deprecated,
+dl.see {
   color: unset;
+  box-shadow: 5px 5px 5px hsla(0, 0%, 19.2%, 0.5);
 }
+
 dl.remark {
-	background: var(--remark-color-bg);
-	border-left: 8px solid var(--remark-color-hl);
+  background: var(--remark-color-bg);
+  border-left: 8px solid var(--remark-color-hl);
 }
+
 dl.remark dt {
-	color: var(--remark-color-hl);
+  color: var(--remark-color-hl);
+}
+
+dl.important dt {
+  color: var(--important-color-hl);
+}
+
+dl.important {
+  background: var(--important-color-bg);
+  border-left: 8px solid var(--important-color-hl);
+}
+
+dl.attention dt {
+  color: var(--attention-color-hl);
+}
+
+dl.attention {
+  background: var(--attention-color-bg);
+  border-left: 8px solid var(--attention-color-hl);
+}
+
+dl.deprecated dt {
+  color: var(--deprecated-color-hl);
+}
+
+dl.deprecated {
+  background: var(--deprecated-color-bg);
+  border-left: 8px solid var(--deprecated-color-hl);
 }
 
 /* special rules to accent `/see` or `/sa` command output */
 dl.see {
-	background: var(--seealso-color-bg);
-	border-left: 8px solid var(--seealso-color-hl);
+  background: var(--seealso-color-bg);
+  border-left: 8px solid var(--seealso-color-hl);
 }
+
 dl.see dt {
-	color: var(--seealso-color-hl);
+  color: var(--seealso-color-hl);
 }
+
 dl.see {
   padding: 10px;
-	margin: 10px 0px;
-	overflow: hidden;
-	margin-left: 0;
-	border-radius: 4px;
+  margin: 10px 0px;
+  overflow: hidden;
+  margin-left: 0;
+  border-radius: 4px;
+}
+
+dl.see dd {
+  margin-left: 0;
 }
 
 /* admonition icons */
@@ -36,72 +77,90 @@ dl.note dt::before {
   background-color: var(--note-color-hl);
   mask-image: var(--note-icon);
 }
+
 dl.see dt::before {
   background-color: var(--seealso-color-hl);
   mask-image: var(--seealso-icon);
 }
+
 dl.remark dt::before {
   background-color: var(--remark-color-hl);
   mask-image: var(--remark-icon);
 }
+
 dl.warning dt::before {
   background-color: var(--warning-color-hl);
   mask-image: var(--warning-icon);
 }
+
 dl.deprecated dt::before {
   background-color: var(--deprecated-color-hl);
   mask-image: var(--deprecated-icon);
 }
+
+dl.important dt::before {
+  background-color: var(--important-color-hl);
+  mask-image: var(--important-icon);
+}
+
+dl.attention dt::before {
+  background-color: var(--attention-color-hl);
+  mask-image: var(--attention-icon);
+}
+
 dl.note dt::before,
 dl.see dt::before,
 dl.warning dt::before,
 dl.remark dt::before,
-dl.deprecated dt::before {
-	vertical-align: middle;
-	background-repeat: no-repeat;
-	content: "";
-	display: inline-block;
-	height: 2em;
-	width: 2em;
+dl.deprecated dt::before,
+dl.important dt::before,
+dl.attention dt::before {
+  vertical-align: middle;
+  background-repeat: no-repeat;
+  content: "";
+  display: inline-block;
+  height: 2em;
+  width: 2em;
   margin-right: 0.25rem;
 }
+
 dl.note dt,
 dl.see dt,
 dl.warning dt,
 dl.remark dt,
-dl.deprecated dt {
+dl.deprecated dt,
+dl.important dt,
+dl.attention dt {
   margin-top: -0.35em;
   margin-bottom: 0.5em;
 }
 
 /* icon SVG data */
 *:root {
-  --note-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M200-200h57l391-391-57-57-391 391v57Zm-80 80v-170l528-527q12-11 26.5-17t30.5-6q16 0 31 6t26 18l55 56q12 11 17.5 26t5.5 30q0 16-5.5 30.5T817-647L290-120H120Zm640-584-56-56 56 56Zm-141 85-28-29 57 57-29-28Z"/></svg>');
-  --seealso-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-320q75 0 127.5-52.5T660-500q0-75-52.5-127.5T480-680q-75 0-127.5 52.5T300-500q0 75 52.5 127.5T480-320Zm0-72q-45 0-76.5-31.5T372-500q0-45 31.5-76.5T480-608q45 0 76.5 31.5T588-500q0 45-31.5 76.5T480-392Zm0 192q-146 0-266-81.5T40-500q54-137 174-218.5T480-800q146 0 266 81.5T920-500q-54 137-174 218.5T480-200Zm0-300Zm0 220q113 0 207.5-59.5T832-500q-50-101-144.5-160.5T480-720q-113 0-207.5 59.5T128-500q50 101 144.5 160.5T480-280Z"/></svg>');
+  --note-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-280q17 0 28.5-11.5T520-320v-160q0-17-11.5-28.5T480-520q-17 0-28.5 11.5T440-480v160q0 17 11.5 28.5T480-280Zm0-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/></svg>');
   --warning-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="m40-120 440-760 440 760H40Zm138-80h604L480-720 178-200Zm302-40q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm-40-120h80v-200h-80v200Zm40-100Z"/></svg>');
-  --remark-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M382-240 154-468l57-57 171 171 367-367 57 57-424 424Z"/></svg>');
+  --remark-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-80q-33 0-56.5-23.5T400-160h160q0 33-23.5 56.5T480-80ZM360-200q-17 0-28.5-11.5T320-240q0-17 11.5-28.5T360-280h240q17 0 28.5 11.5T640-240q0 17-11.5 28.5T600-200H360Zm-30-120q-69-41-109.5-110T180-580q0-125 87.5-212.5T480-880q125 0 212.5 87.5T780-580q0 81-40.5 150T630-320H330Zm24-80h252q45-32 69.5-79T700-580q0-92-64-156t-156-64q-92 0-156 64t-64 156q0 54 24.5 101t69.5 79Zm126 0Z"/></svg>');
+  --attention-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-280q17 0 28.5-11.5T520-320q0-17-11.5-28.5T480-360q-17 0-28.5 11.5T440-320q0 17 11.5 28.5T480-280Zm0-160q17 0 28.5-11.5T520-480v-160q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640v160q0 17 11.5 28.5T480-440ZM363-120q-16 0-30.5-6T307-143L143-307q-11-11-17-25.5t-6-30.5v-234q0-16 6-30.5t17-25.5l164-164q11-11 25.5-17t30.5-6h234q16 0 30.5 6t25.5 17l164 164q11 11 17 25.5t6 30.5v234q0 16-6 30.5T817-307L653-143q-11 11-25.5 17t-30.5 6H363Zm1-80h232l164-164v-232L596-760H364L200-596v232l164 164Zm116-280Z"/></svg>');
+  --important-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-360q17 0 28.5-11.5T520-400q0-17-11.5-28.5T480-440q-17 0-28.5 11.5T440-400q0 17 11.5 28.5T480-360Zm0-160q17 0 28.5-11.5T520-560v-160q0-17-11.5-28.5T480-760q-17 0-28.5 11.5T440-720v160q0 17 11.5 28.5T480-520ZM240-240l-92 92q-19 19-43.5 8.5T80-177v-623q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240Zm-34-80h594v-480H160v525l46-45Zm-46 0v-480 480Z"/></svg>');
+  --seealso-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M480-320q75 0 127.5-52.5T660-500q0-75-52.5-127.5T480-680q-75 0-127.5 52.5T300-500q0 75 52.5 127.5T480-320Zm0-72q-45 0-76.5-31.5T372-500q0-45 31.5-76.5T480-608q45 0 76.5 31.5T588-500q0 45-31.5 76.5T480-392Zm0 192q-146 0-266-81.5T40-500q54-137 174-218.5T480-800q146 0 266 81.5T920-500q-54 137-174 218.5T480-200Zm0-300Zm0 220q113 0 207.5-59.5T832-500q-50-101-144.5-160.5T480-720q-113 0-207.5 59.5T128-500q50 101 144.5 160.5T480-280Z"/></svg>');
   --deprecated-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z"/></svg>');
 }
 
 /* color overrides */
-html {
-  /* light theme CSS variables */
-  --note-color-bg: hsla(47.6, 77.3%, 91.4%, 65%);
-  --warning-color-bg: hsla(6.8, 75.9%, 88.6%, 65%);
-  --deprecated-color-bg: hsla(205.7, 22.6%, 93.9%, 65%);
-  --seealso-color-bg: hsla(215, 76%, 89%, 65%);
-  --seealso-color-hl: hsl(215, 98%, 48%);
-  --remark-color-bg: hsla(133, 75%, 89%, 65%);
-  --remark-color-hl: hsl(133, 98.9%, 35.3%);
-}
-
+html,
 html.dark-mode {
-  /* dark theme CSS variables */
-  --note-color-bg: hsla(45.8, 87.3%, 12.4%, 65%);
-  --warning-color-bg: hsla(5.2, 33.3%, 13.5%, 65%);
-  --deprecated-color-bg: hsla(221.5, 12.4%, 20.6%, 65%);
-  --seealso-color-bg: hsla(215, 33%, 14%, 0.65);
-  --seealso-color-hl: hsl(215, 98%, 48%);
-  --remark-color-bg: hsla(133, 32%, 14%, 65%);
-  --remark-color-hl: hsl(133, 98%, 48%);
+  --note-color-hl: hsl(213.7, 92.8%, 62%);
+  --note-color-bg: hsla(213.7, 92.8%, 62%, 12.5%);
+  --warning-color-hl: hsl(40.6, 72.1%, 47.8%);
+  --warning-color-bg: hsla(40.6, 72.1%, 47.8%, 12.5%);
+  --attention-color-hl: hsl(2.7, 92.6%, 62.9%);
+  --attention-color-bg: hsla(2.7, 92.6%, 62.9%, 12.5%);
+  --deprecated-color-hl: hsl(0, 0%, 47%);
+  --deprecated-color-bg: hsla(0, 0%, 47%, 12.5%);
+  --seealso-color-hl: hsl(323, 72%, 52%);
+  --seealso-color-bg: hsla(323, 72%, 52%, 12.5%);
+  --remark-color-hl: hsl(128.4, 49.2%, 48.6%);
+  --remark-color-bg: hsla(128.4, 49.2%, 48.6%, 12.5%);
+  --important-color-hl: hsl(262.4, 89.8%, 73.1%);
+  --important-color-bg: hsla(262.4, 89.8%, 73.1%, 12.5%);
 }


### PR DESCRIPTION
This also upgrades to doxygen to v1.11.0 which now supports [github-style admonitions](https://www.doxygen.nl/manual/markdown.html#mddox_github_alerts).

Basically, we can write the following in markdown:
```markdown
> [!note]
> is translated to `\note`

> [!warning]
> is translated to `\warning`

> [!tip]
> is translated to `\remark`

> [!caution]
> is translated to `\attention`

> [!important]
> is translated to `\important`
```

and it will render in doxygen and github as admonitions:

> [!note]
> is translated to `\note`

> [!warning]
> is translated to `\warning`

> [!tip]
> is translated to `\remark`

> [!caution]
> is translated to `\attention`

> [!important]
> is translated to `\important`

However, these special blockquotes are root-level syntax only. Meaning you cannot nest these admonitions in other block elements (like list items). This limitation is due to commonmark specifications and is observed in both github and doxygen output.