### PR TITLE
fix: make `available(pipe)` depend on `available(void)`

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1488,23 +1488,18 @@ uint8_t RF24::getDynamicPayloadSize(void)
 
 bool RF24::available(void)
 {
-    uint8_t pipe = RF24_NO_FETCH_PIPE;
-    return available(&pipe);
+    return (read_register(FIFO_STATUS) & 1) == 0;
 }
 
 /****************************************************************************/
 
 bool RF24::available(uint8_t* pipe_num)
 {
-    if (read_register(FIFO_STATUS) & 1) { // if RX FIFO is empty
-        return 0;
-    }
-
-    // If the caller wants the pipe number, include that
-    if (*pipe_num != RF24_NO_FETCH_PIPE)
+    if (available()) { // if RX FIFO is not empty
         *pipe_num = (get_status() >> RX_P_NO) & 0x07;
-
-    return 1;
+        return 1;
+    }
+    return 0;
 }
 
 /****************************************************************************/
@@ -1756,8 +1751,7 @@ bool RF24::writeAckPayload(uint8_t pipe, const void* buf, uint8_t len)
 
 bool RF24::isAckPayloadAvailable(void)
 {
-    uint8_t pipe = RF24_NO_FETCH_PIPE;
-    return available(&pipe);
+    return available();
 }
 
 /****************************************************************************/

--- a/RF24_config.h
+++ b/RF24_config.h
@@ -44,9 +44,6 @@
     #define RF24_SPI_SPEED 10000000
 #endif
 
-/// A sentinel used to control fetching the pipe info in `RF24::available()`.
-#define RF24_NO_FETCH_PIPE 0XFF
-
 //ATXMega
 #if defined(__AVR_ATxmega64D3__) || defined(__AVR_ATxmega128D3__) || defined(__AVR_ATxmega192D3__) || defined(__AVR_ATxmega256D3__) || defined(__AVR_ATxmega384D3__)
     // In order to be available both in Windows and Linux this should take presence here.


### PR DESCRIPTION
I've been code golfing in rust again (on rf24-rs)...

By making `available(pipe)` call `available(void)`, we can get the same behavior without instantiating a dummy byte (`RF24_FETCH_NO_PIPE`) . This way `available(pipe)` also doesn't need to check the `pipe` parameter's value; it just mutates it because that is the overload's purpose.

This should decrease the compile size in general, more for any app that doesn't actually call `available(pipe)`.
