### PR TITLE
Update doc comment for default linux gpiochip

### DIFF
--- a/utility/SPIDEV/gpio.h
+++ b/utility/SPIDEV/gpio.h
@@ -21,10 +21,7 @@ typedef uint16_t rf24_gpio_pin_t;
 #define RF24_PIN_INVALID 0xFFFF
 
 #ifndef RF24_LINUX_GPIO_CHIP
-    /**
-     * The default GPIO chip to use.  Defaults to `/dev/gpiochip4` (for RPi5).
-     * Falls back to `/dev/gpiochip0` if this value is somehow incorrect.
-     */
+    /// The default GPIO chip to use.  Defaults to `/dev/gpiochip0`.
     #define RF24_LINUX_GPIO_CHIP "/dev/gpiochip0"
 #endif
 


### PR DESCRIPTION
I missed this in #1018 

no actual code changes. just a comment change.