### PR TITLE
Pipe0 fix

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1188,7 +1188,9 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    write_register(RX_ADDR_P0, pipe0_writing_address, addr_width);
+    uint8_t tx_addr[addr_width];
+    read_register(TX_ADDR, tx_addr, addr_width);
+    write_register(RX_ADDR_P0, tx_addr, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 
@@ -1566,7 +1568,6 @@ void RF24::openWritingPipe(uint64_t value)
 
     write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), addr_width);
     write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), addr_width);
-    memcpy(pipe0_writing_address, &value, addr_width);
 }
 
 /****************************************************************************/
@@ -1577,7 +1578,6 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
-    memcpy(pipe0_writing_address, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1188,7 +1188,7 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    openWritingPipe(pipe0_writing_address);
+    write_register(RX_ADDR_P0, pipe0_writing_address, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1188,9 +1188,7 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    uint8_t tx_addr[addr_width];
-    read_register(TX_ADDR, tx_addr, addr_width);
-    write_register(RX_ADDR_P0, tx_addr, addr_width);
+    write_register(RX_ADDR_P0, pipe0_writing_address, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 
@@ -1568,6 +1566,7 @@ void RF24::openWritingPipe(uint64_t value)
 
     write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), addr_width);
     write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), addr_width);
+    memcpy(pipe0_writing_address, &value, addr_width);
 }
 
 /****************************************************************************/
@@ -1578,6 +1577,7 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
+    memcpy(pipe0_writing_address, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1188,6 +1188,7 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
+    openWritingPipe(pipe0_writing_address);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 
@@ -1565,6 +1566,7 @@ void RF24::openWritingPipe(uint64_t value)
 
     write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), addr_width);
     write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), addr_width);
+    memcpy(pipe0_writing_address, &value, addr_width);
 }
 
 /****************************************************************************/
@@ -1575,6 +1577,7 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
+    memcpy(pipe0_writing_address, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.h
+++ b/RF24.h
@@ -158,6 +158,7 @@ private:
     uint8_t status;                   /* The status byte returned from every SPI transaction */
     uint8_t payload_size;             /* Fixed size of payloads */
     uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
+    uint8_t pipe0_writing_address[5]; /* Last address set on pipe 0 for writing. */
     uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
     bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
     bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */

--- a/RF24.h
+++ b/RF24.h
@@ -158,7 +158,6 @@ private:
     uint8_t status;                   /* The status byte returned from every SPI transaction */
     uint8_t payload_size;             /* Fixed size of payloads */
     uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
-    uint8_t pipe0_writing_address[5]; /* Last address set on pipe 0 for writing. */
     uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
     bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
     bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */

--- a/RF24.h
+++ b/RF24.h
@@ -352,9 +352,13 @@ public:
      * radio.write(&data, sizeof(data));
      * @endcode
      *
-     * @note When the ACK payloads feature is enabled, the TX FIFO buffers are
+     * @warning When the ACK payloads feature is enabled, the TX FIFO buffers are
      * flushed when calling this function. This is meant to discard any ACK
      * payloads that were not appended to acknowledgment packets.
+     *
+     * @note For auto-ack purposes, the TX address passed to openWritingPipe() will be restored to
+     * RX pipe 0. This still means that `stopListening()` shall be called before
+     * calling openWritingPipe() because the TX address is cached in openWritingPipe().
      */
     void stopListening(void);
 
@@ -523,10 +527,13 @@ public:
      * @see
      * - setAddressWidth()
      * - startListening()
+     * - stopListening()
      *
      * @param address The address to be used for outgoing transmissions (uses
      * pipe 0). Coordinate this address amongst other receiving nodes (the
-     * pipe numbers don't need to match).
+     * pipe numbers don't need to match). This address is cached to ensure proper
+     * auto-ack behavior; stopListening() will always restore the latest cached TX
+     * address.
      *
      * @remark There is no address length parameter because this function will
      * always write the number of bytes that the radio addresses are configured


### PR DESCRIPTION
- Caches and restores the writing address upon calling `stopListening()` & `openWritingPipe()`

Closes #1028 

> [!note]
> The order of function calls remains the same. `stopListening()` should still be called before `openWritingPipe()`.
