### PR TITLE
refactor: migrate to `stopListening(txAddress)` from `openWritingPipe()`

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -50,5 +50,5 @@ jobs:
     uses: nRF24/.github/.github/workflows/build_docs.yaml@main
     with:
       deploy-gh-pages: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') }}
-      doxygen-version: '1.12.0'
+      doxygen-version: '1.13.2'
     secrets: inherit

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
   commands:
     # Install doxygen from source distributions (conda forge does not keep up-to-date doxygen releases)
     - >
-      DOXYGEN_VERSION="1.12.0" &&
+      DOXYGEN_VERSION="1.13.2" &&
       mkdir .doxygen && cd .doxygen &&
       echo $(pwd) &&
       echo "https://sourceforge.net/projects/doxygen/files/rel-$DOXYGEN_VERSION/doxygen-$DOXYGEN_VERSION.linux.bin.tar.gz" &&

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -2048,6 +2048,11 @@ void RF24::stopConstCarrier()
     powerDown(); // per datasheet recommendation (just to be safe)
     write_register(RF_SETUP, static_cast<uint8_t>(read_register(RF_SETUP) & ~_BV(CONT_WAVE) & ~_BV(PLL_LOCK)));
     ce(LOW);
+    flush_tx();
+    if (isPVariant()) {
+        // restore the cached TX address
+        write_register(TX_ADDR, pipe0_writing_address, addr_width);
+    }
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1614,6 +1614,7 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
+    memcpy(pipe0_writing_address, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -603,7 +603,8 @@ void RF24::_init_obj()
     _spi = &SPI;
 #endif // defined (RF24_SPI_PTR)
 
-    pipe0_reading_address[0] = 0;
+    memset(pipe0_reading_address, 0, 5);
+    memset(txAddress, 0xE7, 5);
     if (spi_speed <= 35000) { //Handle old BCM2835 speed constants, default to RF24_SPI_SPEED
         spi_speed = RF24_SPI_SPEED;
     }
@@ -1186,7 +1187,8 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    write_register(RX_ADDR_P0, pipe0_writing_address, addr_width);
+    write_register(TX_ADDR, txAddress, addr_width);
+    write_register(RX_ADDR_P0, txAddress, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 
@@ -1595,7 +1597,7 @@ void RF24::openWritingPipe(uint64_t value)
 
     write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), addr_width);
     write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), addr_width);
-    memcpy(pipe0_writing_address, &value, addr_width);
+    memcpy(txAddress, &value, addr_width);
 }
 
 /****************************************************************************/
@@ -1606,7 +1608,7 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
-    memcpy(pipe0_writing_address, address, addr_width);
+    memcpy(txAddress, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1185,17 +1185,17 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    write_register(RX_ADDR_P0, txAddress, addr_width);
+    write_register(RX_ADDR_P0, pipe0_writing_address, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
 }
 
 /****************************************************************************/
 
-void RF24::stopListening(const uint8_t* tx_address)
+void RF24::stopListening(const uint8_t* txAddress)
 {
-    memcpy(txAddress, tx_address, addr_width);
+    memcpy(pipe0_writing_address, txAddress, addr_width);
     stopListening();
-    write_register(TX_ADDR, txAddress, addr_width);
+    write_register(TX_ADDR, pipe0_writing_address, addr_width);
 }
 
 /****************************************************************************/
@@ -1603,7 +1603,7 @@ void RF24::openWritingPipe(uint64_t value)
 
     write_register(RX_ADDR_P0, reinterpret_cast<uint8_t*>(&value), addr_width);
     write_register(TX_ADDR, reinterpret_cast<uint8_t*>(&value), addr_width);
-    memcpy(txAddress, &value, addr_width);
+    memcpy(pipe0_writing_address, &value, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1191,6 +1191,15 @@ void RF24::stopListening(void)
 
 /****************************************************************************/
 
+void RF24::stopListening(const uint64_t txAddress)
+{
+    memcpy(pipe0_writing_address, &txAddress, addr_width);
+    stopListening();
+    write_register(TX_ADDR, pipe0_writing_address, addr_width);
+}
+
+/****************************************************************************/
+
 void RF24::stopListening(const uint8_t* txAddress)
 {
     memcpy(pipe0_writing_address, txAddress, addr_width);

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1187,9 +1187,17 @@ void RF24::stopListening(void)
         powerUp();
     }
 #endif
-    write_register(TX_ADDR, txAddress, addr_width);
     write_register(RX_ADDR_P0, txAddress, addr_width);
     write_register(EN_RXADDR, static_cast<uint8_t>(read_register(EN_RXADDR) | _BV(pgm_read_byte(&child_pipe_enable[0])))); // Enable RX on pipe0
+}
+
+/****************************************************************************/
+
+void RF24::stopListening(const uint8_t* tx_address)
+{
+    memcpy(txAddress, tx_address, addr_width);
+    startListening();
+    write_register(TX_ADDR, txAddress, addr_width);
 }
 
 /****************************************************************************/
@@ -1608,7 +1616,6 @@ void RF24::openWritingPipe(const uint8_t* address)
     // expects it LSB first too, so we're good.
     write_register(RX_ADDR_P0, address, addr_width);
     write_register(TX_ADDR, address, addr_width);
-    memcpy(txAddress, address, addr_width);
 }
 
 /****************************************************************************/

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -603,8 +603,6 @@ void RF24::_init_obj()
     _spi = &SPI;
 #endif // defined (RF24_SPI_PTR)
 
-    memset(pipe0_reading_address, 0, 5);
-    memset(txAddress, 0xE7, 5);
     if (spi_speed <= 35000) { //Handle old BCM2835 speed constants, default to RF24_SPI_SPEED
         spi_speed = RF24_SPI_SPEED;
     }

--- a/RF24.h
+++ b/RF24.h
@@ -390,13 +390,6 @@ public:
     void stopListening(const uint8_t* txAddress);
 
     /**
-     * @brief Similar to startListening(void) but changes the TX address.
-     * @param txAddress The new TX address.
-     * This value will be cached for auto-ack purposes.
-     */
-    void stopListening(const uint64_t txAddress);
-
-    /**
      * Check whether there are bytes available to be read
      * @code
      * if(radio.available()){
@@ -2033,6 +2026,17 @@ public:
      * @endcode
      */
     void whatHappened(bool& tx_ok, bool& tx_fail, bool& rx_ready);
+
+    /**
+     * Similar to startListening(void) but changes the TX address.
+     *
+     * @deprecated Use stopListening(const uint8_t*) instead.
+     * See our [migration guide](migration.md) to understand what you should update in your code.
+     *
+     * @param txAddress The new TX address.
+     * This value will be cached for auto-ack purposes.
+     */
+    void stopListening(const uint64_t txAddress);
 
 private:
     /**@}*/

--- a/RF24.h
+++ b/RF24.h
@@ -396,12 +396,14 @@ public:
      * @warning When the ACK payloads feature is enabled, the TX FIFO buffers are
      * flushed when calling this function. This is meant to discard any ACK
      * payloads that were not appended to acknowledgment packets.
-     *
-     * @note For auto-ack purposes, the TX address passed to openWritingPipe() will be restored to
-     * RX pipe 0. This still means that `stopListening()` shall be called before
-     * calling openWritingPipe() because the TX address is cached in openWritingPipe().
      */
     void stopListening(void);
+
+    /**
+     * @brief Similar to startListening(void) but changes the TX address.
+     * @param tx_address The new TX address. This value will be cached to `txAddress` member.
+     */
+    void stopListening(const uint8_t* tx_address);
 
     /**
      * Check whether there are bytes available to be read
@@ -540,8 +542,7 @@ public:
      * New: Open a pipe for writing via byte array. Old addressing format retained
      * for compatibility.
      *
-     * @deprecated Use `RF24::txAddress` instead.
-     * As of v1.5, using this function is slower than using `RF24::txAddress`.
+     * @deprecated Use `RF24::txAddress`  or `RF24::stopListening(uint8_t*)` instead.
      *
      * Only one writing pipe can be opened at once, but this function changes
      * the address that is used to transmit (ACK payloads/packets do not apply

--- a/RF24.h
+++ b/RF24.h
@@ -182,7 +182,6 @@ private:
     uint8_t status;                   /* The status byte returned from every SPI transaction */
     uint8_t payload_size;             /* Fixed size of payloads */
     uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
-    uint8_t pipe0_writing_address[5]; /* Last address set on pipe 0 for writing. */
     uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
     bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
     bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */
@@ -368,6 +367,24 @@ public:
     void startListening(void);
 
     /**
+     * The TX address to use on pipe 0 for writing.
+     *
+     * This is cached in the library to ensure proper auto-ack behavior on pipe 0,
+     * if pipe 0 is also used with a different RX address for receiving.
+     *
+     * Use this instead of calling openWritingPipe()
+     *
+     * ```cpp
+     * uint8_t rxNodeAddress[6] = "1Node";
+     * memcpy(radio.txAddress, rxNodeAddress, 5);
+     * radio.stopListening();
+     * ```
+     *
+     * Previously, openWritingPipe() should be called after stopListening().
+     */
+    uint8_t txAddress[5];
+
+    /**
      * Stop listening for incoming messages, and switch to transmit mode.
      *
      * Do this before calling write().
@@ -522,6 +539,9 @@ public:
     /**
      * New: Open a pipe for writing via byte array. Old addressing format retained
      * for compatibility.
+     *
+     * @deprecated Use `RF24::txAddress` instead.
+     * As of v1.5, using this function is slower than using `RF24::txAddress`.
      *
      * Only one writing pipe can be opened at once, but this function changes
      * the address that is used to transmit (ACK payloads/packets do not apply

--- a/RF24.h
+++ b/RF24.h
@@ -182,6 +182,7 @@ private:
     uint8_t status;                   /* The status byte returned from every SPI transaction */
     uint8_t payload_size;             /* Fixed size of payloads */
     uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
+    uint8_t pipe0_writing_address[5]; /* Last address set on pipe 0 for writing. */
     uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
     bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
     bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */
@@ -367,24 +368,6 @@ public:
     void startListening(void);
 
     /**
-     * The TX address to use on pipe 0 for writing.
-     *
-     * This is cached in the library to ensure proper auto-ack behavior on pipe 0,
-     * if pipe 0 is also used with a different RX address for receiving.
-     *
-     * Use this instead of calling openWritingPipe()
-     *
-     * ```cpp
-     * uint8_t rxNodeAddress[6] = "1Node";
-     * memcpy(radio.txAddress, rxNodeAddress, 5);
-     * radio.stopListening();
-     * ```
-     *
-     * Previously, openWritingPipe() should be called after stopListening().
-     */
-    uint8_t txAddress[5];
-
-    /**
      * Stop listening for incoming messages, and switch to transmit mode.
      *
      * Do this before calling write().
@@ -401,9 +384,10 @@ public:
 
     /**
      * @brief Similar to startListening(void) but changes the TX address.
-     * @param tx_address The new TX address. This value will be cached to `txAddress` member.
+     * @param txAddress The new TX address.
+     * This value will be cached for auto-ack purposes.
      */
-    void stopListening(const uint8_t* tx_address);
+    void stopListening(const uint8_t* txAddress);
 
     /**
      * Check whether there are bytes available to be read
@@ -542,7 +526,7 @@ public:
      * New: Open a pipe for writing via byte array. Old addressing format retained
      * for compatibility.
      *
-     * @deprecated Use `RF24::txAddress`  or `RF24::stopListening(uint8_t*)` instead.
+     * @deprecated Use `RF24::stopListening(uint8_t*)` instead.
      *
      * Only one writing pipe can be opened at once, but this function changes
      * the address that is used to transmit (ACK payloads/packets do not apply

--- a/RF24.h
+++ b/RF24.h
@@ -390,6 +390,13 @@ public:
     void stopListening(const uint8_t* txAddress);
 
     /**
+     * @brief Similar to startListening(void) but changes the TX address.
+     * @param txAddress The new TX address.
+     * This value will be cached for auto-ack purposes.
+     */
+    void stopListening(const uint64_t txAddress);
+
+    /**
      * Check whether there are bytes available to be read
      * @code
      * if(radio.available()){

--- a/RF24.h
+++ b/RF24.h
@@ -179,12 +179,12 @@ private:
     uint8_t spi_rxbuff[32 + 1]; //SPI receive buffer (payload max 32 bytes)
     uint8_t spi_txbuff[32 + 1]; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
 #endif
-    uint8_t status;                   /* The status byte returned from every SPI transaction */
-    uint8_t payload_size;             /* Fixed size of payloads */
-    uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
-    uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
-    bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
-    bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */
+    uint8_t status;                         /* The status byte returned from every SPI transaction */
+    uint8_t payload_size;                   /* Fixed size of payloads */
+    uint8_t pipe0_reading_address[5] = {0}; /* Last address set on pipe 0 for reading. */
+    uint8_t config_reg;                     /* For storing the value of the NRF_CONFIG register */
+    bool _is_p_variant;                     /* For storing the result of testing the toggleFeatures() affect */
+    bool _is_p0_rx;                         /* For keeping track of pipe 0's usage in user-triggered RX mode. */
 
 protected:
     /**
@@ -382,7 +382,7 @@ public:
      *
      * Previously, openWritingPipe() should be called after stopListening().
      */
-    uint8_t txAddress[5];
+    uint8_t txAddress[5] = {0xE7};
 
     /**
      * Stop listening for incoming messages, and switch to transmit mode.

--- a/RF24.h
+++ b/RF24.h
@@ -179,12 +179,12 @@ private:
     uint8_t spi_rxbuff[32 + 1]; //SPI receive buffer (payload max 32 bytes)
     uint8_t spi_txbuff[32 + 1]; //SPI transmit buffer (payload max 32 bytes + 1 byte for the command)
 #endif
-    uint8_t status;                         /* The status byte returned from every SPI transaction */
-    uint8_t payload_size;                   /* Fixed size of payloads */
-    uint8_t pipe0_reading_address[5] = {0}; /* Last address set on pipe 0 for reading. */
-    uint8_t config_reg;                     /* For storing the value of the NRF_CONFIG register */
-    bool _is_p_variant;                     /* For storing the result of testing the toggleFeatures() affect */
-    bool _is_p0_rx;                         /* For keeping track of pipe 0's usage in user-triggered RX mode. */
+    uint8_t status;                   /* The status byte returned from every SPI transaction */
+    uint8_t payload_size;             /* Fixed size of payloads */
+    uint8_t pipe0_reading_address[5]; /* Last address set on pipe 0 for reading. */
+    uint8_t config_reg;               /* For storing the value of the NRF_CONFIG register */
+    bool _is_p_variant;               /* For storing the result of testing the toggleFeatures() affect */
+    bool _is_p0_rx;                   /* For keeping track of pipe 0's usage in user-triggered RX mode. */
 
 protected:
     /**
@@ -382,7 +382,7 @@ public:
      *
      * Previously, openWritingPipe() should be called after stopListening().
      */
-    uint8_t txAddress[5] = {0xE7};
+    uint8_t txAddress[5];
 
     /**
      * Stop listening for incoming messages, and switch to transmit mode.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -30,24 +30,32 @@ if radio.available() { /* .. */ }
 
 </td></tr></table>
 
-## openReadingPipe(uint8_t, uint64_t) and openWritingPipe(uint64_t)
+## 64-bit integer addresses
 
-> **Deprecated since v1.3.11**
+Any function that accept an address in the form of `uint64_t` is discouraged. This includes
 
-These functions' address parameter used a 64-bit unsigned integer (`uint64_t`).
+- `RF24::openReadingPipe(uint8_t, uint64_t)`
+   > **Deprecated since v1.3.11**
+- `RF24::openWritingPipe(uint64_t)`
+   > **Deprecated since v1.3.11**
+- `RF24::stopListening(const uint64_t)`
+   > **Deprecated since v1.5**
+
+These functions' address parameter use a 64-bit unsigned integer (`uint64_t`).
 The nRF24L01 can only use up to 40 bit addresses.
-Thus, there was an unused 24 bits being allocated for addresses using this function.
+Thus, there is an unused 24 bits being allocated for addresses using these functions.
 
 There are overloaded functions that use a buffer instead:
 
 - `RF24::openReadingPipe(uint8_t, const uint8_t*)`
 - `RF24::openWritingPipe(const uint8_t*)`
+- `RF24::stopListening(const uint8_t*)`
 
 These eliminate the unnecessary 24 bits by only using the length of the buffer (`uint8_t*`)
 specified by `RF24::setAddressWidth()`.
 
 @see The `RF24::openWritingPipe(const uint8_t*)` is now deprecated in favor of the
-overloaded `RF24::stopListening(uint8_t*)` function.
+overloaded `RF24::stopListening(const uint8_t*)` function.
 See the section below for more detail.
 
 > [!CAUTION]
@@ -181,6 +189,7 @@ The aptly named `RF24::clearStatusFlags()` is designed to be a replacement for `
 Like `RF24::clearStatusFlags()`, `RF24::setStatusFlags()` takes 1 parameter whose value is defined by
 the `rf24_irq_flags_e` enumerated constants. These constant values specify individual flags;
 they can also be OR'd together to specify multiple flags.
+
 Additionally, `RF24::clearStatusFlags()` returns the STATUS byte containing the flags that
 caused the IRQ pin to go active LOW.
 This allows the user code to allocate less memory when diagnosing the IRQ pin's meaning.
@@ -229,10 +238,11 @@ Unfortunately, there was a bug that prevented the given TX address from being
 persistent on pipe 0 if the user code also set an RX address to pipe 0.
 This bug would surface when switching between RX mode and TX mode (via
 `RF24::startListening()` and `RF24::stopListening()` respectively) or after
-`RF24::stopConstCarrier()`.
-As a result the TX address has to be cached on the `RF24` instance.
-Consequently, this solution does not fit well with the traditional order of
-setting up the radio.
+`RF24::stopConstCarrier()` (if `RF24::isPVariant()` returns `true`).
+
+The solution is to cache the TX address on the `RF24` instance.
+Consequently, this solution did not fit well with the traditional order of
+functions used to set up the radio's TX or RX mode.
 
 By overloading `RF24::stopListening(const uint8_t*)`, we are able to ensure proper radio
 setup without requiring certain functions are called in a certain order.

--- a/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
+++ b/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
@@ -84,18 +84,16 @@ void setup() {
   // this feature for all nodes (TX & RX) to use ACK payloads.
   radio.enableAckPayload();
 
-  // set the TX address of the RX node for use on the TX pipe (pipe 0)
-  memcpy(radio.txAddress, address[radioNumber], 5);
-
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
+
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  radio.stopListening(address[radioNumber]);  // put radio in TX mode
 
   // additional setup specific to the node's role
   if (role) {
     // setup the TX payload
-
     memcpy(payload.message, "Hello ", 6);  // set the payload message
-    radio.stopListening();                 // put radio in TX mode
   } else {
     // setup the ACK payload & load the first response into the FIFO
 

--- a/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
+++ b/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
@@ -84,11 +84,11 @@ void setup() {
   // this feature for all nodes (TX & RX) to use ACK payloads.
   radio.enableAckPayload();
 
-  // set the RX address of the TX node into a RX pipe
-  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
-
   // set the TX address of the RX node for use on the TX pipe (pipe 0)
   radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // set the RX address of the TX node into a RX pipe
+  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
   // additional setup specific to the node's role
   if (role) {

--- a/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
+++ b/examples/AcknowledgementPayloads/AcknowledgementPayloads.ino
@@ -84,8 +84,8 @@ void setup() {
   // this feature for all nodes (TX & RX) to use ACK payloads.
   radio.enableAckPayload();
 
-  // set the TX address of the RX node into the TX pipe
-  radio.openWritingPipe(address[radioNumber]);  // always uses pipe 0
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1

--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -74,16 +74,14 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // float datatype occupies 4 bytes
 
-  // set the TX address of the RX node for use on the TX pipe (pipe 0)
-  memcpy(radio.txAddress, address[radioNumber], 5);
-
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
-  // additional setup specific to the node's role
-  if (role) {
-    radio.stopListening();  // put radio in TX mode
-  } else {
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // additional setup specific to the node's RX role
+  if (!role) {
     radio.startListening();  // put radio in RX mode
   }
 

--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -74,11 +74,11 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // float datatype occupies 4 bytes
 
-  // set the RX address of the TX node into a RX pipe
-  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
-
   // set the TX address of the RX node for use on the TX pipe (pipe 0)
   radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // set the RX address of the TX node into a RX pipe
+  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
   // additional setup specific to the node's RX role
   if (!role) {

--- a/examples/GettingStarted/GettingStarted.ino
+++ b/examples/GettingStarted/GettingStarted.ino
@@ -74,8 +74,8 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // float datatype occupies 4 bytes
 
-  // set the TX address of the RX node into the TX pipe
-  radio.openWritingPipe(address[radioNumber]);  // always uses pipe 0
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1

--- a/examples/InterruptConfigure/InterruptConfigure.ino
+++ b/examples/InterruptConfigure/InterruptConfigure.ino
@@ -102,20 +102,15 @@ void setup() {
   // Acknowledgement packets have no payloads by default. We need to enable
   // this feature for all nodes (TX & RX) to use ACK payloads.
   radio.enableAckPayload();
-  // Fot this example, we use the same address to send data back and forth
-
-  // set the TX address of the RX node for use on the TX pipe (pipe 0)
-  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
-  // additional setup specific to the node's role
-  if (role) {
-    // setup for TX mode
-    radio.stopListening();  // put radio in TX mode
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  radio.stopListening(address[radioNumber]);  // put radio in TX mode
 
-  } else {
+  // additional setup specific to the node's RX role
+  if (!role) {
     // setup for RX mode
 
     // let IRQ pin only trigger on "data_ready" event in RX mode

--- a/examples/InterruptConfigure/InterruptConfigure.ino
+++ b/examples/InterruptConfigure/InterruptConfigure.ino
@@ -104,8 +104,8 @@ void setup() {
   radio.enableAckPayload();
   // Fot this example, we use the same address to send data back and forth
 
-  // set the TX address of the RX node into the TX pipe
-  radio.openWritingPipe(address[radioNumber]);  // always uses pipe 0
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1

--- a/examples/InterruptConfigure/InterruptConfigure.ino
+++ b/examples/InterruptConfigure/InterruptConfigure.ino
@@ -103,11 +103,11 @@ void setup() {
   // this feature for all nodes (TX & RX) to use ACK payloads.
   radio.enableAckPayload();
 
-  // set the RX address of the TX node into a RX pipe
-  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
-
   // set the TX address of the RX node for use on the TX pipe (pipe 0)
   radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // set the RX address of the TX node into a RX pipe
+  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
   // additional setup specific to the node's RX role
   if (!role) {

--- a/examples/ManualAcknowledgements/ManualAcknowledgements.ino
+++ b/examples/ManualAcknowledgements/ManualAcknowledgements.ino
@@ -88,17 +88,16 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // char[7] & uint8_t datatypes occupy 8 bytes
 
-  // set the TX address of the RX node for use on the TX pipe (pipe 0)
-  memcpy(radio.txAddress, address[radioNumber], 5);
-
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
+
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  radio.stopListening(address[radioNumber]);  // put radio in TX mode
 
   if (role) {
     // setup the TX node
 
     memcpy(payload.message, "Hello ", 6);  // set the outgoing message
-    radio.stopListening();                 // put radio in TX mode
   } else {
     // setup the RX node
 

--- a/examples/ManualAcknowledgements/ManualAcknowledgements.ino
+++ b/examples/ManualAcknowledgements/ManualAcknowledgements.ino
@@ -88,8 +88,8 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // char[7] & uint8_t datatypes occupy 8 bytes
 
-  // set the TX address of the RX node into the TX pipe
-  radio.openWritingPipe(address[radioNumber]);  // always uses pipe 0
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1

--- a/examples/ManualAcknowledgements/ManualAcknowledgements.ino
+++ b/examples/ManualAcknowledgements/ManualAcknowledgements.ino
@@ -88,11 +88,11 @@ void setup() {
   // number of bytes we need to transmit a float
   radio.setPayloadSize(sizeof(payload));  // char[7] & uint8_t datatypes occupy 8 bytes
 
-  // set the RX address of the TX node into a RX pipe
-  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
-
   // set the TX address of the RX node for use on the TX pipe (pipe 0)
   radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // set the RX address of the TX node into a RX pipe
+  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
   if (role) {
     // setup the TX node

--- a/examples/MulticeiverDemo/MulticeiverDemo.ino
+++ b/examples/MulticeiverDemo/MulticeiverDemo.ino
@@ -184,8 +184,7 @@ void setRole() {
     payload.payloadID = 0;
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[role], 5);
-    radio.stopListening();  // put radio in TX mode
+    radio.stopListening(address[role]);  // put radio in TX mode
 
     // According to the datasheet, the auto-retry features's delay value should
     // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples/MulticeiverDemo/MulticeiverDemo.ino
+++ b/examples/MulticeiverDemo/MulticeiverDemo.ino
@@ -27,13 +27,13 @@ RF24 radio(CE_PIN, CSN_PIN);
 // an identifying device destination
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
-// because they use the same first 4 bytes from pipe 1.
-uint64_t address[6] = { 0x7878787878LL,
-                        0xB3B4B5B6F1LL,
-                        0xB3B4B5B6CDLL,
-                        0xB3B4B5B6A3LL,
-                        0xB3B4B5B60FLL,
-                        0xB3B4B5B605LL };
+// because they use the same first 4 MSBytes from pipe 1.
+uint8_t address[6][6] = { { 0x78, 0x78, 0x78, 0x78, 0x78 },
+                          { 0xF1, 0xB6, 0xB5, 0xB4, 0xB3 },
+                          { 0xCD, 0xB6, 0xB5, 0xB4, 0xB3 },
+                          { 0xA3, 0xB6, 0xB5, 0xB4, 0xB3 },
+                          { 0x0F, 0xB6, 0xB5, 0xB4, 0xB3 },
+                          { 0x05, 0xB6, 0xB5, 0xB4, 0xB3 } };
 
 // role variable is used to control whether this node is sending or receiving
 char role = 'R';  // integers 0-5 = TX node; character 'R' or integer 82 = RX node
@@ -183,9 +183,9 @@ void setRole() {
     payload.nodeID = role;
     payload.payloadID = 0;
 
-    // Set the address on pipe 0 to the RX node.
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[role], 5);
     radio.stopListening();  // put radio in TX mode
-    radio.openWritingPipe(address[role]);
 
     // According to the datasheet, the auto-retry features's delay value should
     // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples/MulticeiverDemo/MulticeiverDemo.ino
+++ b/examples/MulticeiverDemo/MulticeiverDemo.ino
@@ -28,7 +28,7 @@ RF24 radio(CE_PIN, CSN_PIN);
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
 // because they use the same first 4 MSBytes from pipe 1.
-uint8_t address[6][6] = { { 0x78, 0x78, 0x78, 0x78, 0x78 },
+uint8_t address[6][5] = { { 0x78, 0x78, 0x78, 0x78, 0x78 },
                           { 0xF1, 0xB6, 0xB5, 0xB4, 0xB3 },
                           { 0xCD, 0xB6, 0xB5, 0xB4, 0xB3 },
                           { 0xA3, 0xB6, 0xB5, 0xB4, 0xB3 },

--- a/examples/StreamingData/StreamingData.ino
+++ b/examples/StreamingData/StreamingData.ino
@@ -80,8 +80,8 @@ void setup() {
   // number of bytes we need to transmit
   radio.setPayloadSize(SIZE);  // default value is the maximum 32 bytes
 
-  // set the TX address of the RX node into the TX pipe
-  radio.openWritingPipe(address[radioNumber]);  // always uses pipe 0
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  memcpy(radio.txAddress, address[radioNumber], 5);
 
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1

--- a/examples/StreamingData/StreamingData.ino
+++ b/examples/StreamingData/StreamingData.ino
@@ -80,16 +80,14 @@ void setup() {
   // number of bytes we need to transmit
   radio.setPayloadSize(SIZE);  // default value is the maximum 32 bytes
 
-  // set the TX address of the RX node for use on the TX pipe (pipe 0)
-  memcpy(radio.txAddress, address[radioNumber], 5);
-
   // set the RX address of the TX node into a RX pipe
   radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
-  // additional setup specific to the node's role
-  if (role) {
-    radio.stopListening();  // put radio in TX mode
-  } else {
+  // set the TX address of the RX node for use on the TX pipe (pipe 0)
+  radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // additional setup specific to the node's RX role
+  if (!role) {
     radio.startListening();  // put radio in RX mode
   }
 

--- a/examples/StreamingData/StreamingData.ino
+++ b/examples/StreamingData/StreamingData.ino
@@ -80,11 +80,11 @@ void setup() {
   // number of bytes we need to transmit
   radio.setPayloadSize(SIZE);  // default value is the maximum 32 bytes
 
-  // set the RX address of the TX node into a RX pipe
-  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
-
   // set the TX address of the RX node for use on the TX pipe (pipe 0)
   radio.stopListening(address[radioNumber]);  // put radio in TX mode
+
+  // set the RX address of the TX node into a RX pipe
+  radio.openReadingPipe(1, address[!radioNumber]);  // using pipe 1
 
   // additional setup specific to the node's RX role
   if (!role) {

--- a/examples_linux/acknowledgementPayloads.cpp
+++ b/examples_linux/acknowledgementPayloads.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/acknowledgementPayloads.cpp
+++ b/examples_linux/acknowledgementPayloads.cpp
@@ -96,8 +96,8 @@ int main(int argc, char** argv)
     // each other.
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/acknowledgement_payloads.py
+++ b/examples_linux/acknowledgement_payloads.py
@@ -51,8 +51,8 @@ radio.enableAckPayload()
 # usually run with nRF24L01 transceivers in close proximity of each other
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
-# set the TX address of the RX node into the TX pipe
-radio.openWritingPipe(address[radio_number])  # always uses pipe 0
+# set the TX address of the RX node for use on the TX pipe (pipe 0)
+radio.txAddress = address[radio_number]
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/acknowledgement_payloads.py
+++ b/examples_linux/acknowledgement_payloads.py
@@ -52,7 +52,7 @@ radio.enableAckPayload()
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
 # set the TX address of the RX node for use on the TX pipe (pipe 0)
-radio.txAddress = address[radio_number]
+radio.stopListening(address[radio_number])
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/getting_started.py
+++ b/examples_linux/getting_started.py
@@ -49,7 +49,7 @@ radio_number = bool(
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
 # set the TX address of the RX node for use on the TX pipe (pipe 0)
-radio.txAddress = address[radio_number]
+radio.stopListening(address[radio_number])
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/getting_started.py
+++ b/examples_linux/getting_started.py
@@ -48,8 +48,8 @@ radio_number = bool(
 # usually run with nRF24L01 transceivers in close proximity of each other
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
-# set the TX address of the RX node into the TX pipe
-radio.openWritingPipe(address[radio_number])  # always uses pipe 0
+# set the TX address of the RX node for use on the TX pipe (pipe 0)
+radio.txAddress = address[radio_number]
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/gettingstarted.cpp
+++ b/examples_linux/gettingstarted.cpp
@@ -87,8 +87,8 @@ int main(int argc, char** argv)
     // each other.
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/gettingstarted.cpp
+++ b/examples_linux/gettingstarted.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/interruptConfigure.cpp
+++ b/examples_linux/interruptConfigure.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv)
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/interruptConfigure.cpp
+++ b/examples_linux/interruptConfigure.cpp
@@ -109,8 +109,8 @@ int main(int argc, char** argv)
     // each other.
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/interrupt_configure.py
+++ b/examples_linux/interrupt_configure.py
@@ -82,8 +82,8 @@ radio.enableAckPayload()  # enable ACK payloads
 # usually run with nRF24L01 transceivers in close proximity of each other
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
-# set the TX address of the RX node into the TX pipe
-radio.openWritingPipe(address[radio_number])  # always uses pipe 0
+# set the TX address of the RX node for use on the TX pipe (pipe 0)
+radio.txAddress = address[radio_number]
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/interrupt_configure.py
+++ b/examples_linux/interrupt_configure.py
@@ -83,7 +83,7 @@ radio.enableAckPayload()  # enable ACK payloads
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
 # set the TX address of the RX node for use on the TX pipe (pipe 0)
-radio.txAddress = address[radio_number]
+radio.stopListening(address[radio_number])
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/manualAcknowledgements.cpp
+++ b/examples_linux/manualAcknowledgements.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
     radio.setPayloadSize(sizeof(payload)); // char[7] & uint8_t datatypes occupy 8 bytes
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/manualAcknowledgements.cpp
+++ b/examples_linux/manualAcknowledgements.cpp
@@ -103,8 +103,8 @@ int main(int argc, char** argv)
     // number of bytes we need to transmit a float
     radio.setPayloadSize(sizeof(payload)); // char[7] & uint8_t datatypes occupy 8 bytes
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/manual_acknowledgements.py
+++ b/examples_linux/manual_acknowledgements.py
@@ -54,8 +54,8 @@ radio_number = bool(
 # usually run with nRF24L01 transceivers in close proximity of each other
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
-# set the TX address of the RX node into the TX pipe
-radio.openWritingPipe(address[radio_number])  # always uses pipe 0
+# set the TX address of the RX node for use on the TX pipe (pipe 0)
+radio.txAddress = address[radio_number]
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/manual_acknowledgements.py
+++ b/examples_linux/manual_acknowledgements.py
@@ -55,7 +55,7 @@ radio_number = bool(
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
 # set the TX address of the RX node for use on the TX pipe (pipe 0)
-radio.txAddress = address[radio_number]
+radio.stopListening(address[radio_number])
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/multiceiverDemo.cpp
+++ b/examples_linux/multiceiverDemo.cpp
@@ -48,7 +48,7 @@ RF24 radio(CE_PIN, CSN_PIN);
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
 // because they use the same first 4 MSBytes from pipe 1.
-uint8_t address[6][6] = {{0x78, 0x78, 0x78, 0x78, 0x78},
+uint8_t address[6][5] = {{0x78, 0x78, 0x78, 0x78, 0x78},
                          {0xF1, 0xB6, 0xB5, 0xB4, 0xB3},
                          {0xCD, 0xB6, 0xB5, 0xB4, 0xB3},
                          {0xA3, 0xB6, 0xB5, 0xB4, 0xB3},

--- a/examples_linux/multiceiverDemo.cpp
+++ b/examples_linux/multiceiverDemo.cpp
@@ -182,8 +182,7 @@ void master(unsigned int role)
     payload.payloadID = 0;
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[role], 5);
-    radio.stopListening(); // put radio in TX mode
+    radio.stopListening(address[role]); // put radio in TX mode
 
     // According to the datasheet, the auto-retry features's delay value should
     // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples_linux/multiceiverDemo.cpp
+++ b/examples_linux/multiceiverDemo.cpp
@@ -47,13 +47,13 @@ RF24 radio(CE_PIN, CSN_PIN);
 // an identifying device destination
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
-// because they use the same first 4 bytes from pipe 1.
-uint64_t address[6] = {0x7878787878LL,
-                       0xB3B4B5B6F1LL,
-                       0xB3B4B5B6CDLL,
-                       0xB3B4B5B6A3LL,
-                       0xB3B4B5B60FLL,
-                       0xB3B4B5B605LL};
+// because they use the same first 4 MSBytes from pipe 1.
+uint8_t address[6][6] = {{0x78, 0x78, 0x78, 0x78, 0x78},
+                         {0xF1, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0xCD, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0xA3, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0x0F, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0x05, 0xB6, 0xB5, 0xB4, 0xB3}};
 
 // For this example, we'll be using a payload containing
 // a node ID number and a single integer number that will be incremented
@@ -181,9 +181,9 @@ void master(unsigned int role)
     payload.nodeID = role;
     payload.payloadID = 0;
 
-    // Set the address on pipe 0 to the RX node.
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[role], 5);
     radio.stopListening(); // put radio in TX mode
-    radio.openWritingPipe(address[role]);
 
     // According to the datasheet, the auto-retry features's delay value should
     // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples_linux/multiceiver_demo.py
+++ b/examples_linux/multiceiver_demo.py
@@ -75,8 +75,7 @@ def master(node_number):
     )  # maximum value is 15 for both args
 
     # set the TX address of the RX node for use on the TX pipe (pipe 0)
-    radio.txAddress = addresses[node_number]
-    radio.stopListening()  # put radio in TX mode
+    radio.stopListening(addresses[node_number])  # put radio in TX mode
 
     counter = 0
     failures = 0

--- a/examples_linux/multiceiver_demo.py
+++ b/examples_linux/multiceiver_demo.py
@@ -74,9 +74,10 @@ def master(node_number):
         ((node_number * 3) % 12) + 3, 15
     )  # maximum value is 15 for both args
 
+    # set the TX address of the RX node for use on the TX pipe (pipe 0)
+    radio.txAddress = addresses[node_number]
     radio.stopListening()  # put radio in TX mode
-    # set the TX address to the address of the base station.
-    radio.openWritingPipe(addresses[node_number])
+
     counter = 0
     failures = 0
     while failures < 6:

--- a/examples_linux/streamingData.cpp
+++ b/examples_linux/streamingData.cpp
@@ -149,8 +149,8 @@ int main(int argc, char** argv)
     // each other.
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/streamingData.cpp
+++ b/examples_linux/streamingData.cpp
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
     radio.setPALevel(RF24_PA_LOW); // RF24_PA_MAX is default.
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_linux/streaming_data.py
+++ b/examples_linux/streaming_data.py
@@ -48,7 +48,7 @@ radio_number = bool(
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
 # set the TX address of the RX node for use on the TX pipe (pipe 0)
-radio.txAddress = address[radio_number]
+radio.stopListening(address[radio_number])
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_linux/streaming_data.py
+++ b/examples_linux/streaming_data.py
@@ -47,8 +47,8 @@ radio_number = bool(
 # usually run with nRF24L01 transceivers in close proximity of each other
 radio.setPALevel(RF24_PA_LOW)  # RF24_PA_MAX is default
 
-# set the TX address of the RX node into the TX pipe
-radio.openWritingPipe(address[radio_number])  # always uses pipe 0
+# set the TX address of the RX node for use on the TX pipe (pipe 0)
+radio.txAddress = address[radio_number]
 
 # set the RX address of the TX node into a RX pipe
 radio.openReadingPipe(1, address[not radio_number])  # using pipe 1

--- a/examples_pico/acknowledgementPayloads.cpp
+++ b/examples_pico/acknowledgementPayloads.cpp
@@ -78,8 +78,8 @@ bool setup()
     // this feature for all nodes (TX & RX) to use ACK payloads.
     radio.enableAckPayload();
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/acknowledgementPayloads.cpp
+++ b/examples_pico/acknowledgementPayloads.cpp
@@ -79,7 +79,7 @@ bool setup()
     radio.enableAckPayload();
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/gettingStarted.cpp
+++ b/examples_pico/gettingStarted.cpp
@@ -67,8 +67,8 @@ bool setup()
     // number of bytes we need to transmit a float
     radio.setPayloadSize(sizeof(payload)); // float datatype occupies 4 bytes
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/gettingStarted.cpp
+++ b/examples_pico/gettingStarted.cpp
@@ -68,7 +68,7 @@ bool setup()
     radio.setPayloadSize(sizeof(payload)); // float datatype occupies 4 bytes
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/interruptConfigure.cpp
+++ b/examples_pico/interruptConfigure.cpp
@@ -97,8 +97,8 @@ bool setup()
     radio.enableAckPayload();
     // Fot this example, we use the same address to send data back and forth
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/interruptConfigure.cpp
+++ b/examples_pico/interruptConfigure.cpp
@@ -98,17 +98,13 @@ bool setup()
     // Fot this example, we use the same address to send data back and forth
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1
 
     // additional setup specific to the node's role
-    if (role) {
-        // setup for TX mode
-        radio.stopListening(); // put radio in TX mode
-    }
-    else {
+    if (!role) {
         // setup for RX mode
 
         // disable IRQ pin in RX mode

--- a/examples_pico/manualAcknowledgements.cpp
+++ b/examples_pico/manualAcknowledgements.cpp
@@ -82,8 +82,8 @@ bool setup()
     // number of bytes we need to transmit a float
     radio.setPayloadSize(sizeof(payload)); // char[7] & uint8_t datatypes occupy 8 bytes
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/manualAcknowledgements.cpp
+++ b/examples_pico/manualAcknowledgements.cpp
@@ -83,7 +83,7 @@ bool setup()
     radio.setPayloadSize(sizeof(payload)); // char[7] & uint8_t datatypes occupy 8 bytes
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1
@@ -92,7 +92,6 @@ bool setup()
         // setup the TX node
 
         memcpy(payload.message, "Hello ", 6); // set the outgoing message
-        radio.stopListening();                // put radio in TX mode
     }
     else {
         // setup the RX node

--- a/examples_pico/multiceiverDemo.cpp
+++ b/examples_pico/multiceiverDemo.cpp
@@ -191,8 +191,7 @@ void setRole()
         payload.payloadID = 0;
 
         // set the TX address of the RX node for use on the TX pipe (pipe 0)
-        memcpy(radio.txAddress, address[role], 5);
-        radio.stopListening(); // put radio in TX mode
+        radio.stopListening(address[role]); // put radio in TX mode
 
         // According to the datasheet, the auto-retry features's delay value should
         // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples_pico/multiceiverDemo.cpp
+++ b/examples_pico/multiceiverDemo.cpp
@@ -28,7 +28,7 @@ RF24 radio(CE_PIN, CSN_PIN);
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
 // because they use the same first 4 MSBytes from pipe 1.
-uint8_t address[6][6] = {{0x78, 0x78, 0x78, 0x78, 0x78},
+uint8_t address[6][5] = {{0x78, 0x78, 0x78, 0x78, 0x78},
                          {0xF1, 0xB6, 0xB5, 0xB4, 0xB3},
                          {0xCD, 0xB6, 0xB5, 0xB4, 0xB3},
                          {0xA3, 0xB6, 0xB5, 0xB4, 0xB3},

--- a/examples_pico/multiceiverDemo.cpp
+++ b/examples_pico/multiceiverDemo.cpp
@@ -27,13 +27,13 @@ RF24 radio(CE_PIN, CSN_PIN);
 // an identifying device destination
 // Notice that the last byte is the only byte that changes in the last 5
 // addresses. This is a limitation of the nRF24L01 transceiver for pipes 2-5
-// because they use the same first 4 bytes from pipe 1.
-uint64_t address[6] = {0x7878787878LL,
-                       0xB3B4B5B6F1LL,
-                       0xB3B4B5B6CDLL,
-                       0xB3B4B5B6A3LL,
-                       0xB3B4B5B60FLL,
-                       0xB3B4B5B605LL};
+// because they use the same first 4 MSBytes from pipe 1.
+uint8_t address[6][6] = {{0x78, 0x78, 0x78, 0x78, 0x78},
+                         {0xF1, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0xCD, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0xA3, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0x0F, 0xB6, 0xB5, 0xB4, 0xB3},
+                         {0x05, 0xB6, 0xB5, 0xB4, 0xB3}};
 
 // Because this example allow up to 6 nodes (specified by numbers 0-5) to
 // transmit and only 1 node to receive, we will use a negative value in our
@@ -190,9 +190,9 @@ void setRole()
         payload.nodeID = role;
         payload.payloadID = 0;
 
-        // Set the address on pipe 0 to the RX node.
+        // set the TX address of the RX node for use on the TX pipe (pipe 0)
+        memcpy(radio.txAddress, address[role], 5);
         radio.stopListening(); // put radio in TX mode
-        radio.openWritingPipe(address[role]);
 
         // According to the datasheet, the auto-retry features's delay value should
         // be "skewed" to allow the RX node to receive 1 transmission at a time.

--- a/examples_pico/streamingData.cpp
+++ b/examples_pico/streamingData.cpp
@@ -73,8 +73,8 @@ bool setup()
     // number of bytes we need to transmit
     radio.setPayloadSize(SIZE); // default value is the maximum 32 bytes
 
-    // set the TX address of the RX node into the TX pipe
-    radio.openWritingPipe(address[radioNumber]); // always uses pipe 0
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(radio.txAddress, address[radioNumber], 5);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1

--- a/examples_pico/streamingData.cpp
+++ b/examples_pico/streamingData.cpp
@@ -74,16 +74,13 @@ bool setup()
     radio.setPayloadSize(SIZE); // default value is the maximum 32 bytes
 
     // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(radio.txAddress, address[radioNumber], 5);
+    radio.stopListening(address[radioNumber]);
 
     // set the RX address of the TX node into a RX pipe
     radio.openReadingPipe(1, address[!radioNumber]); // using pipe 1
 
     // additional setup specific to the node's role
-    if (role) {
-        radio.stopListening(); // put radio in TX mode
-    }
-    else {
+    if (!role) {
         radio.startListening(); // put radio in RX mode
     }
 

--- a/pyRF24/pyRF24.cpp
+++ b/pyRF24/pyRF24.cpp
@@ -39,21 +39,6 @@ int get_bytes_or_bytearray_ln(bp::object buf)
     return 0;
 }
 
-void set_tx_address(RF24& ref, bp::object buf)
-{
-    // set the TX address of the RX node for use on the TX pipe (pipe 0)
-    memcpy(ref.txAddress, get_bytes_or_bytearray_str(buf), get_bytes_or_bytearray_ln(buf));
-}
-
-bp::object get_tx_address(RF24& ref)
-{
-    char* buf = new char[6];
-    memcpy(buf, ref.txAddress, 5);
-    bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, 5)));
-    delete[] buf;
-    return py_ba;
-}
-
 bp::object read_wrap(RF24& ref, int maxlen)
 {
     char* buf = new char[maxlen + 1];
@@ -348,8 +333,6 @@ BOOST_PYTHON_MODULE(RF24)
         .def("openReadingPipe", (void(::RF24::*)(::uint8_t, ::uint64_t))(&::RF24::openReadingPipe), (bp::arg("number"), bp::arg("address")))
         .def("openWritingPipe", &openWritingPipe_wrap, (bp::arg("address")))
         .def("openWritingPipe", (void(::RF24::*)(::uint64_t))(&::RF24::openWritingPipe), (bp::arg("address")))
-        .add_property("txAddress", &get_tx_address, &set_tx_address)
-        .add_property("tx_address", &get_tx_address, &set_tx_address)
         .def("powerDown", &RF24::powerDown)
         .def("powerUp", &RF24::powerUp)
         .def("printDetails", &RF24::printDetails)
@@ -374,7 +357,7 @@ BOOST_PYTHON_MODULE(RF24)
         .def("startListening", &RF24::startListening)
         .def("startWrite", &startWrite_wrap, (bp::arg("buf"), bp::arg("len"), bp::arg("multicast")))
         .def("stopListening", (void(::RF24::*)(void))(&RF24::stopListening))
-        .def("stopListening", &stopListening_wrap, (bp::arg("tx_address")))
+        .def("stopListening", &stopListening_wrap, (bp::arg("txAddress")))
         .def("testCarrier", &RF24::testCarrier)
         .def("testRPD", &RF24::testRPD)
         .def("toggleAllPipes", &RF24::toggleAllPipes)

--- a/pyRF24/pyRF24.cpp
+++ b/pyRF24/pyRF24.cpp
@@ -39,6 +39,21 @@ int get_bytes_or_bytearray_ln(bp::object buf)
     return 0;
 }
 
+void set_tx_address(RF24& ref, bp::object buf)
+{
+    // set the TX address of the RX node for use on the TX pipe (pipe 0)
+    memcpy(ref.txAddress, get_bytes_or_bytearray_str(buf), get_bytes_or_bytearray_ln(buf));
+}
+
+bp::object get_tx_address(RF24& ref)
+{
+    char* buf = new char[6];
+    memcpy(buf, ref.txAddress, 5);
+    bp::object py_ba(bp::handle<>(PyByteArray_FromStringAndSize(buf, 5)));
+    delete[] buf;
+    return py_ba;
+}
+
 bp::object read_wrap(RF24& ref, int maxlen)
 {
     char* buf = new char[maxlen + 1];
@@ -328,6 +343,8 @@ BOOST_PYTHON_MODULE(RF24)
         .def("openReadingPipe", (void(::RF24::*)(::uint8_t, ::uint64_t))(&::RF24::openReadingPipe), (bp::arg("number"), bp::arg("address")))
         .def("openWritingPipe", &openWritingPipe_wrap, (bp::arg("address")))
         .def("openWritingPipe", (void(::RF24::*)(::uint64_t))(&::RF24::openWritingPipe), (bp::arg("address")))
+        .add_property("txAddress", &get_tx_address, &set_tx_address)
+        .add_property("tx_address", &get_tx_address, &set_tx_address)
         .def("powerDown", &RF24::powerDown)
         .def("powerUp", &RF24::powerUp)
         .def("printDetails", &RF24::printDetails)

--- a/pyRF24/pyRF24.cpp
+++ b/pyRF24/pyRF24.cpp
@@ -113,6 +113,11 @@ void openWritingPipe_wrap(RF24& ref, const bp::object address)
     ref.openWritingPipe((const uint8_t*)(get_bytes_or_bytearray_str(address)));
 }
 
+void stopListening_wrap(RF24& ref, const bp::object address)
+{
+    ref.stopListening((const uint8_t*)(get_bytes_or_bytearray_str(address)));
+}
+
 void openReadingPipe_wrap(RF24& ref, uint8_t number, const bp::object address)
 {
     ref.openReadingPipe(number, (const uint8_t*)(get_bytes_or_bytearray_str(address)));
@@ -368,7 +373,8 @@ BOOST_PYTHON_MODULE(RF24)
         .def("startFastWrite", &startFastWrite_wrap2, (bp::arg("buf"), bp::arg("len"), bp::arg("multicast"), bp::arg("startTx")))
         .def("startListening", &RF24::startListening)
         .def("startWrite", &startWrite_wrap, (bp::arg("buf"), bp::arg("len"), bp::arg("multicast")))
-        .def("stopListening", &RF24::stopListening)
+        .def("stopListening", (void(::RF24::*)(void))(&RF24::stopListening))
+        .def("stopListening", &stopListening_wrap, (bp::arg("tx_address")))
         .def("testCarrier", &RF24::testCarrier)
         .def("testRPD", &RF24::testRPD)
         .def("toggleAllPipes", &RF24::toggleAllPipes)


### PR DESCRIPTION
`stopListening()` now writes the TX address to pipe 0 (for reading and writing). This deprecates the need for `openWritingPipe()` by offering an overloaded `stopListening(txAddress)`.

All examples (and the python wrapper) have been updated to use the new public `stopListening(txAddress)` accordingly.

> [!important]
> RF24Network should be updated to use the new `stopListening(txAddress)` also. This approach should retain current performance in networking layers while still satisfying #1028.

The main take away is no duplicate SPI transactions when switching to TX mode and (re)setting the TX address. This aims to fix the performance regression in #1029.