### PR TITLE
Fix for Dynamic Payloads

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -1505,9 +1505,8 @@ uint8_t RF24::getDynamicPayloadSize(void)
 {
     uint8_t result = read_register(R_RX_PL_WID);
 
-    if (result > 32) {
+    if (result > 32 || !result) {
         flush_rx();
-        delay(2);
         return 0;
     }
     return result;


### PR DESCRIPTION
- The rx buffer also needs to be flushed if R_RX_PL_WID returns 0
- No need for the delay

https://github.com/nRF24/RF24Network/pull/249