### PR TITLE
chore: use nushell as a task runner

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -259,6 +259,7 @@ words:
   - tableofcontents
   - TEENSYDUINO
   - THINGPLUS
+  - timeit
   - toctree
   - TOLOWER
   - transfern

--- a/nurfile
+++ b/nurfile
@@ -44,13 +44,22 @@ def "nur docs" [
 
 
 def find-built-examples [path: string] {
-(
-        ls $path
-        | where {$in.type == "file"}
-        | get "name"
-        | filter {'.' not-in $in}
-        | filter {($in | str ends-with "Makefile") == false}
+    let len = $nur.project-path | str length
+    let example_path_len = ($path | str length) + 2
+    let sources = (
+        glob $"($path)/**/*.cpp" --exclude [
+            "**/build/**"
+        ]
+        | each {$in | str substring ($len + $example_path_len)..-5}
     )
+    let binaries = (
+        glob $"($path)/build/**/*" --exclude [
+            "**/CMakeFiles/**"
+        ]
+        | each {$in | str substring ($len + $example_path_len + 6)..}
+        | filter {$in in $sources}
+    )
+    $binaries 
 }
 
 
@@ -76,14 +85,11 @@ def "nur examples" [
     run-cmd cmake --build $build_dir
 
     print $"(ansi green)Built the following examples:(ansi reset)"
-    let binaries = find-built-examples $build_dir
-    if ($build_dir | path join "ncurses" | path exists) {
-        let ncurses_example = find-built-examples $"($build_dir)/ncurses"
-        let binaries = $binaries | append $ncurses_example
-        print $binaries
-    } else {
-        print $binaries
-    }
+    let binaries = (
+        find-built-examples $src_dir
+        | each {$"($build_dir)/($in)"}
+    )
+    print $binaries
 }
 
 

--- a/nurfile
+++ b/nurfile
@@ -154,7 +154,16 @@ def changed-files [] {
         | rename "state" "name"
     )
     # print $changed
-    let result = $changed | where {is-changed $in.state} | get "name"
+    let result = (
+        $changed
+        | where {is-changed $in.state}
+        | get "name"
+        | each {
+            if ($in | str contains " -> ") {
+                $in | parse "{a} -> {b}" | get "b" | $in.0
+            } else { $in }
+        }
+    )
     # print $result
     $result
 }

--- a/nurfile
+++ b/nurfile
@@ -208,5 +208,5 @@ def "nur fmt" [
         print $files
         run-external $bin_name "-i" "--style" "file" ...$files
     }
-    print $"Applied clang-format to ($files | length) files"
+    print $"(ansi blue)Applied clang-format to ($files | length) files(ansi reset)"
 }

--- a/nurfile
+++ b/nurfile
@@ -152,29 +152,23 @@ def "nur py" [
 }
 
 
-def is-changed [state: string] {
-    $state | split chars | each {$in in ['A' 'M' 'R']} | reduce {$in}
-}
-
-
 def changed-files [] {
-    let status = git status --short | str trim 
-    if ($status | str length) == 0 {
+    let status = git status --short | lines
+    if ($status | length) == 0 {
         print $"(ansi red)No file changes detected via (ansi cyan)`git status`(ansi reset)"
         print $"Perhaps you want to format all files? (ansi cyan)`nut fmt -a`"
         return []
     }
     let changed = (
         $status
-        | split row --regex '\n'
-        | each {$in | str trim | split column --regex '\s+' -n 1}
+        | each {$in | str trim | split column --regex '\s+' -n 2}
         | flatten
         | rename "state" "name"
     )
     # print $changed
     let result = (
         $changed
-        | where {is-changed $in.state}
+        | where {$in.state | split chars | each {$in in ['A' 'M' 'R']} | any {$in}}
         | get "name"
         | each {
             if ($in | str contains " -> ") {

--- a/nurfile
+++ b/nurfile
@@ -86,12 +86,13 @@ def "nur examples" [
 }
 
 
-# Install the library.
+# Build/install the library.
 #
 # Note, this may ask for the password to
 # install the library with super-user privileges.
 def --wrapped "nur lib" [
     --dirty (-d) # Reuse previous build env
+    --no-install # Do not install the library (useful for testing compilation)
     ...cmake_opts: string # additional args passed to cmake when configuring the build env
 ] {
     let build_dir = "build"
@@ -101,7 +102,9 @@ def --wrapped "nur lib" [
         run-cmd cmake -B build -S . ...$cmake_opts
     }
     run-cmd cmake --build $build_dir
-    run-cmd sudo cmake --install $build_dir
+    if $no_install == false {
+        run-cmd sudo cmake --install $build_dir
+    }
 }
 
 

--- a/nurfile
+++ b/nurfile
@@ -142,16 +142,15 @@ def --wrapped "nur pico" [
 def "nur py" [
     --dirty (-d) # Reuse previous build env
 ] {
-    let dir = ls */setup.py | get "name" | first | path dirname
-    print $"(ansi green)Found wrapper(ansi reset) in ($dir)"
-    let artifacts = glob $"($dir)/{build,*.egg-info}"
+    let src_dir = "pyRF24"
+    let artifacts = glob $"($src_dir)/{build,*.egg-info}"
     if ($artifacts | length) > 0 {
         if $dirty == false {
             print $"(ansi yellow)Removing artifacts(ansi reset) ($artifacts | str join ' ')"
             rm -r ...$artifacts
         }
     }
-    run-cmd pip install -v $"./($dir)"
+    run-cmd pip install -v $"./($src_dir)"
 }
 
 
@@ -159,7 +158,7 @@ def changed-files [] {
     let status = git status --short | lines
     if ($status | length) == 0 {
         print $"(ansi red)No file changes detected via (ansi cyan)`git status`(ansi reset)"
-        print $"Perhaps you want to format all files? (ansi cyan)`nut fmt -a`"
+        print $"Perhaps you want to format all files? (ansi cyan)`nur fmt -a`"
         return []
     }
     let changed = (

--- a/nurfile
+++ b/nurfile
@@ -184,6 +184,50 @@ def changed-files [] {
 }
 
 
+def get-clang-format-version [bin_name: string] {
+    if (which $bin_name | is-empty) {
+        null
+    } else {
+        let version = (
+            ^$bin_name --version
+            | split column ' '
+            | values
+            | flatten
+            | last
+        )
+        print $"($bin_name) --version: ($version)"
+        $version | parse "{major}.{minor}.{patch}"
+    }
+}
+
+
+def match-version [
+    bin_name: string,
+    expected: string = "14",
+    --throw
+] {
+    let version = get-clang-format-version $bin_name
+    if ($version | is-empty) {
+        if $throw {
+            error make {
+                msg: $"($bin_name) not found. Ensure it is installed and added to your PATH."
+            }
+        }
+        false
+    } else { 
+        if ($version.major.0 == $expected) {
+            true
+        } else if $throw {
+            error make {
+                msg: $"Failed to find clang-format v($expected).x"
+            }
+        } else {
+            false
+        }
+    }
+}
+
+
 # Run clang-format on C++ files.
 #
 # By default, only changed C++ sources are formatted (uses `git status`).
@@ -213,12 +257,20 @@ def "nur fmt" [
     }
 
     let bin_name = if (is-windows) {
-        let ver = (^"clang-format" --version | split words) | skip 3 | str join '.'
-        if ($ver | str starts-with "14") == false {
-            error-make { msg: $"clang-format v($ver) found; expected v14.x"}
-        }
+        let bin_name = "clang-format"
+        let is_expected = match-version $bin_name --throw
         "clang-format"
-    } else {"clang-format-14"}
+    } else {
+        let bin_name = "clang-format-14"
+        let is_expected = match-version $bin_name
+        if ($is_expected == false) {
+            let bin_name = "clang-format"
+            let is_expected = match-version $bin_name --throw
+            $bin_name
+        } else {
+            $bin_name
+        }
+    }
 
     if ($files | length) > 0 {
         print $files

--- a/nurfile
+++ b/nurfile
@@ -7,7 +7,8 @@ def is-windows [] {
 
 def --wrapped run-cmd [...cmd: string] {
     print $"\n(ansi blue)Running(ansi reset) ($cmd | str join ' ')"
-    ^($cmd | first) ...($cmd | skip 1)
+    let elapsed = timeit {|| ^($cmd | first) ...($cmd | skip 1)}
+    print $"(ansi magenta)($cmd | first) took ($elapsed)(ansi reset)"
 }
 
 
@@ -221,7 +222,8 @@ def "nur fmt" [
 
     if ($files | length) > 0 {
         print $files
-        run-external $bin_name "-i" "--style" "file" ...$files
+        let elapsed = timeit {|| $files | par-each {|f| ^$bin_name "-i" "--style" "file" $f}}
+        print $"clang-format took ($elapsed) using parallelism!"
     }
     print $"(ansi blue)Applied clang-format to ($files | length) files(ansi reset)"
 }

--- a/nurfile
+++ b/nurfile
@@ -1,0 +1,87 @@
+
+# build the docs# install the library
+def "nur docs" [] {
+    cd docs
+    doxygen
+}
+
+# build the Linux examples
+def "nur examples" [] {
+    cmake -B examples_linux/build examples_linux
+    cmake --build examples_linux/build
+}
+
+# install the library
+def "nur lib" [] {
+    cmake -B build -S .
+    cmake --build build
+    sudo cmake --install build
+}
+
+# build the Pico SDK examples
+def "nur pico" [] {
+    cmake -B examples_pico/build examples_pico
+    cmake --build examples_pico/build
+}
+
+# install the  python wrapper
+def "nur py" [] {
+    pip install -v ./pyRF24
+}
+
+def is-changed [state: string] {
+    $state | split chars | each {$in in ['A' 'M' 'R']} | reduce {$in}
+}
+
+def changed-files [] {
+    let status = git status --short | split row --regex '\n'
+    # print $status
+    let changed = (
+        $status
+        | each {$in | str trim | split column --regex '\s+' -n 2}
+        | flatten
+        | rename "state" "name"
+    )
+    # print $changed
+    let result = $changed | where {is-changed $in.state} | get "name"
+    # print $result
+    $result
+}
+
+# run clang-format on all files
+def "nur fmt" [--all (-a)] {
+    let all_files = glob "**/*.{h,cpp,c,ino}" --exclude [
+        "**/build/**"
+        "utility/RPi/bcm2835.*"
+        "examples/old_backups/**"
+        "examples_linux/{interrupts,extra}/*"
+    ] | path relative-to $nur.project-path
+    let files = if $all {
+        $all_files
+    } else {
+        let changes = changed-files
+        (
+            $all_files
+            | where {
+                ($in | path split) in (
+                    $changes | each {$in | path split}
+                )
+            }
+        )
+    }
+
+    let is_windows = $nu.os-info | get "family" | str starts-with "windows"
+    let bin_name = if $is_windows {
+        let ver = (^"clang-format" --version | split words) | skip 3 | str join '.'
+        if ($ver | str starts-with "14") == false {
+            error-make { msg: $"clang-format v($ver) found; expected v14.x"}
+        }
+        "clang-format"
+    } else {"clang-format-14"}
+
+    if ($files | length) > 0 {
+        print $files
+        run-external $bin_name "-i" "--style" "file" ...$files
+    }
+    print $"Applied clang-format to ($files | length) files"
+}

--- a/nurfile
+++ b/nurfile
@@ -158,10 +158,16 @@ def is-changed [state: string] {
 
 
 def changed-files [] {
-    let status = git status --short | split row --regex '\n'
+    let status = git status --short | str trim 
+    if ($status | str length) == 0 {
+        print $"(ansi red)No file changes detected via (ansi cyan)`git status`(ansi reset)"
+        print $"Perhaps you want to format all files? (ansi cyan)`nut fmt -a`"
+        return []
+    }
     let changed = (
         $status
-        | each {$in | str trim | split column --regex '\s+' -n 2}
+        | split row --regex '\n'
+        | each {$in | str trim | split column --regex '\s+' -n 1}
         | flatten
         | rename "state" "name"
     )

--- a/nurfile
+++ b/nurfile
@@ -8,6 +8,16 @@ def --wrapped run-cmd [...cmd: string] {
     ^($cmd | first) ...($cmd | skip 1)
 }
 
+def flush-artifacts [
+    build_dir: string, dirty: bool
+] {
+    if ($build_dir | path exists) {
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
+            rm -r $build_dir
+        }
+    }
+}
 # Build the docs.
 #
 # Note, there is no check against what
@@ -17,12 +27,7 @@ def "nur docs" [
     --open (-o) # Open the built docs in your default browser
 ] {
     let build_dir = "docs/html"
-    if ($build_dir | path exists) {
-        if $dirty == false {
-            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
-            rm -r $build_dir
-        }
-    }
+    flush-artifacts $build_dir $dirty
     cd docs
     run-cmd doxygen
     if $open {
@@ -53,12 +58,7 @@ def "nur examples" [
     let src_dir = "examples_linux"
     let build_dir = $"($src_dir)/build"
 
-    if ($build_dir | path exists) {
-        if $dirty == false {
-            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
-            rm -r $build_dir
-        }
-    }
+    flush-artifacts $build_dir $dirty
 
     if $dirty == false {
         run-cmd cmake -B $build_dir $src_dir ...$cmake_opts
@@ -87,12 +87,8 @@ def --wrapped "nur lib" [
     ...cmake_opts: string # additional args passed to cmake when configuring the build env
 ] {
     let build_dir = "build"
-    if ($build_dir | path exists) {
-        if $dirty == false {
-            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
-            rm -r $build_dir
-        }
-    }
+    flush-artifacts $build_dir $dirty
+
     if $dirty == false {
         run-cmd cmake -B build -S . ...$cmake_opts
     }
@@ -111,12 +107,7 @@ def --wrapped "nur pico" [
 ] {
     let src_dir = "examples_pico"
     let build_dir = $"($src_dir)/build"
-    if ($build_dir | path exists) {
-        if $dirty == false {
-            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
-            rm -r $build_dir
-        }
-    }
+    flush-artifacts $build_dir $dirty
 
     let use_ninja = '-G Ninja'
     let opts = if (is-windows) {
@@ -142,8 +133,10 @@ def "nur py" [
     print $"(ansi green)Found wrapper(ansi reset) in ($dir)"
     let artifacts = glob $"($dir)/{build,*.egg-info}"
     if ($artifacts | length) > 0 {
-        print $"(ansi yellow)Removing artifacts(ansi reset) ($artifacts | str join ' ')"
-        rm -r ...$artifacts
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($artifacts | str join ' ')"
+            rm -r ...$artifacts
+        }
     }
     run-cmd pip install -v $"./($dir)"
 }

--- a/nurfile
+++ b/nurfile
@@ -1,32 +1,151 @@
 
-# build the docs# install the library
-def "nur docs" [] {
+def is-windows [] {
+    $nu.os-info | get "family" | str starts-with "windows"
+}
+
+def --wrapped run-cmd [...cmd: string] {
+    print $"\n(ansi blue)Running(ansi reset) ($cmd | str join ' ')"
+    ^($cmd | first) ...($cmd | skip 1)
+}
+
+# Build the docs.
+#
+# Note, there is no check against what
+# version of doxygen is used.
+def "nur docs" [
+    --dirty (-d) # Do not flush previous build artifacts
+    --open (-o) # Open the built docs in your default browser
+] {
+    let build_dir = "docs/html"
+    if ($build_dir | path exists) {
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
+            rm -r $build_dir
+        }
+    }
     cd docs
-    doxygen
+    run-cmd doxygen
+    if $open {
+        let root_pg = $nur.project-path | path join $"($build_dir)/index.html"
+        start $root_pg
+    }
 }
 
-# build the Linux examples
-def "nur examples" [] {
-    cmake -B examples_linux/build examples_linux
-    cmake --build examples_linux/build
+def find-built-examples [path: string] {
+(
+        ls $path
+        | where {$in.type == "file"}
+        | get "name"
+        | filter {'.' not-in $in}
+        | filter {($in | str ends-with "Makefile") == false}
+    )
 }
 
-# install the library
-def "nur lib" [] {
-    cmake -B build -S .
-    cmake --build build
-    sudo cmake --install build
+# Build the Linux examples.
+#
+# This task expects the library to be installed.
+# CMake will build any ncurses examples if
+# the libncurses5-dev package is installed
+def "nur examples" [
+    --dirty (-d) # Reuse previous build env
+    ...cmake_opts: string # additional args passed to cmake when configuring the build env
+] {
+    let src_dir = "examples_linux"
+    let build_dir = $"($src_dir)/build"
+
+    if ($build_dir | path exists) {
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
+            rm -r $build_dir
+        }
+    }
+
+    if $dirty == false {
+        run-cmd cmake -B $build_dir $src_dir ...$cmake_opts
+    } else if ($build_dir | path exists) == false {
+        run-cmd cmake -B $build_dir $src_dir ...$cmake_opts
+    }
+    run-cmd cmake --build $build_dir
+
+    print $"(ansi green)Built the following examples:(ansi reset)"
+    let binaries = find-built-examples $build_dir
+    if ($build_dir | path join "ncurses" | path exists) {
+        let ncurses_example = find-built-examples $"($build_dir)/ncurses"
+        let binaries = $binaries | append $ncurses_example
+        print $binaries
+    } else {
+        print $binaries
+    }
 }
 
-# build the Pico SDK examples
-def "nur pico" [] {
-    cmake -B examples_pico/build examples_pico
-    cmake --build examples_pico/build
+# Install the library.
+#
+# Note, this may ask for the password to
+# install the library with super-user privileges.
+def --wrapped "nur lib" [
+    --dirty (-d) # Reuse previous build env
+    ...cmake_opts: string # additional args passed to cmake when configuring the build env
+] {
+    let build_dir = "build"
+    if ($build_dir | path exists) {
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
+            rm -r $build_dir
+        }
+    }
+    if $dirty == false {
+        run-cmd cmake -B build -S . ...$cmake_opts
+    }
+    run-cmd cmake --build $build_dir
+    run-cmd sudo cmake --install $build_dir
 }
 
-# install the  python wrapper
-def "nur py" [] {
-    pip install -v ./pyRF24
+# Build the Pico SDK examples.
+#
+# If building on Windows, then `-G Ninja` is
+# automatically passed to CMake when configuring the
+# build environment.
+def --wrapped "nur pico" [
+    --dirty (-d) # Reuse previous build env
+    ...cmake_opts: string # additional args passed to cmake when configuring the build env
+] {
+    let src_dir = "examples_pico"
+    let build_dir = $"($src_dir)/build"
+    if ($build_dir | path exists) {
+        if $dirty == false {
+            print $"(ansi yellow)Removing artifacts(ansi reset) ($build_dir)"
+            rm -r $build_dir
+        }
+    }
+
+    let use_ninja = '-G Ninja'
+    let opts = if (is-windows) {
+        $cmake_opts | append $use_ninja
+    } else { $cmake_opts }
+
+    if $dirty == false {
+        run-cmd cmake -B $build_dir $src_dir ...$opts
+    } else if ($build_dir | path exists) == false {
+        run-cmd cmake -B $build_dir $src_dir ...$opts
+    }
+    run-cmd cmake --build $build_dir
+}
+
+# Install the python wrapper.
+#
+# Note, this task requires the library
+# (& boost.python) to be installed.
+def "nur py" [
+    --dirty (-d) # Reuse previous build env
+] {
+    let dir = ls */setup.py | get "name" | first | path dirname
+    print $"(ansi green)Found wrapper(ansi reset) in ($dir)"
+    let artifacts = glob $"($dir)/{build,*.egg-info}"
+    if ($artifacts | length) > 0 {
+        print $"(ansi yellow)Removing artifacts(ansi reset) ($artifacts | str join ' ')"
+        rm -r ...$artifacts
+    }
+    run-cmd pip install -v $"./($dir)"
 }
 
 def is-changed [state: string] {
@@ -35,7 +154,6 @@ def is-changed [state: string] {
 
 def changed-files [] {
     let status = git status --short | split row --regex '\n'
-    # print $status
     let changed = (
         $status
         | each {$in | str trim | split column --regex '\s+' -n 2}
@@ -48,8 +166,14 @@ def changed-files [] {
     $result
 }
 
-# run clang-format on all files
-def "nur fmt" [--all (-a)] {
+# Run clang-format on C++ files.
+#
+# By default, only changed C++ sources are formatted (uses `git status`).
+# The clang-format version is expected to be v14.
+# If v14 is not found, then an error is thrown.
+def "nur fmt" [
+    --all (-a) # Format all C++ sources
+] {
     let all_files = glob "**/*.{h,cpp,c,ino}" --exclude [
         "**/build/**"
         "utility/RPi/bcm2835.*"
@@ -70,8 +194,7 @@ def "nur fmt" [--all (-a)] {
         )
     }
 
-    let is_windows = $nu.os-info | get "family" | str starts-with "windows"
-    let bin_name = if $is_windows {
+    let bin_name = if (is-windows) {
         let ver = (^"clang-format" --version | split words) | skip 3 | str join '.'
         if ($ver | str starts-with "14") == false {
             error-make { msg: $"clang-format v($ver) found; expected v14.x"}

--- a/nurfile
+++ b/nurfile
@@ -1,12 +1,15 @@
 
+
 def is-windows [] {
     $nu.os-info | get "family" | str starts-with "windows"
 }
+
 
 def --wrapped run-cmd [...cmd: string] {
     print $"\n(ansi blue)Running(ansi reset) ($cmd | str join ' ')"
     ^($cmd | first) ...($cmd | skip 1)
 }
+
 
 def flush-artifacts [
     build_dir: string, dirty: bool
@@ -18,6 +21,8 @@ def flush-artifacts [
         }
     }
 }
+
+
 # Build the docs.
 #
 # Note, there is no check against what
@@ -36,6 +41,7 @@ def "nur docs" [
     }
 }
 
+
 def find-built-examples [path: string] {
 (
         ls $path
@@ -45,6 +51,7 @@ def find-built-examples [path: string] {
         | filter {($in | str ends-with "Makefile") == false}
     )
 }
+
 
 # Build the Linux examples.
 #
@@ -78,6 +85,7 @@ def "nur examples" [
     }
 }
 
+
 # Install the library.
 #
 # Note, this may ask for the password to
@@ -95,6 +103,7 @@ def --wrapped "nur lib" [
     run-cmd cmake --build $build_dir
     run-cmd sudo cmake --install $build_dir
 }
+
 
 # Build the Pico SDK examples.
 #
@@ -122,6 +131,7 @@ def --wrapped "nur pico" [
     run-cmd cmake --build $build_dir
 }
 
+
 # Install the python wrapper.
 #
 # Note, this task requires the library
@@ -141,9 +151,11 @@ def "nur py" [
     run-cmd pip install -v $"./($dir)"
 }
 
+
 def is-changed [state: string] {
     $state | split chars | each {$in in ['A' 'M' 'R']} | reduce {$in}
 }
+
 
 def changed-files [] {
     let status = git status --short | split row --regex '\n'
@@ -167,6 +179,7 @@ def changed-files [] {
     # print $result
     $result
 }
+
 
 # Run clang-format on C++ files.
 #


### PR DESCRIPTION
This is completely optional. It allows simplifying (local) dev workflow by using [nushell] (isolated) as a task runner via nur.

[nushell]: https://www.nushell.sh/
[nur]: https://nur-taskrunner.github.io/docs/quickstart.html

## Requirements
[nur] needs to be installed locally. 

> [!note]
> [nushell] is compiled as the backend implementation of [nur].
> Therefore, [nushell] does not need to be installed.

### Windows
It is easier to just install `nur` from [the github release assets](https://github.com/nur-taskrunner/nur/releases).

### Linux
Unfortunately, `nur` needs to be built from it's rust sources.
1. Install rust with [rustup](rustup.rs) and follow the prompts. If installing on a RPi, then I recommend selecting a "minimal" install configuration (instead of the "default" configuration) to avoid wasting disk space. The minimal configuration can also be set later with `rustup set profile minimal`, but the std lib docs will still exist on disk until upgrading to the next rust release.
2. Install `nur` from source using `cargo install nur --locked`. The `--locked` option is important (uses the `nur` project's cargo.locked manifest).

## Using `nur`
Once [nur] is installed you can list the tasks defined in the file named "nurfile".

| task name | what it does |
|-----------|--------------|
| `nur docs` | Builds docs with doxygen. This task also accepts an `--open` (or `-o`) option (switch) to open the built docs in your default browser. |
| `nur examples` | Builds the Linux examples. Built binaries will reside in `examples_linux/build` directory. |
| `nur fmt` | Runs clang-format (v14) on changed C++ sources. This task also accepts an `--all` (or `-a`) option (switch) to run clang-format on all C++ sources. |
| `nur lib` | Builds and installs the RF24 library using cmake |
| `nur pico` | Builds the Pico SDK examples. Built binaries will reside in `examples_pico/build` directory. |
| `nur py` | Install the python wrapper. Requires the lib (& boost.python) to be installed. |

> [!tip]
> All tasks except `nur fmt` accept a `--dirty` (or `-d`) flag to reuse an existing build env. If no build env exists, then one will be configured.
>
> The tasks that use CMake (`nur lib`, `nur examples`, and `nur pico`) also forward any additional arguments passed (except `-d, --dirty`) in to `cmake`. This allows further configuring the build as needed.
> ```
> # build Pico SDK examples for the Adafruit QtPy board
> nur pico -DPICO_BOARD=adafruit_qtpy_rp2040
> ```

### Reminder
All tasks have their own `--help` (`-h`) option.

<details><summary><code>nur fmt -h</code></summary>
<p>

```
nur version 0.16.0+0.104.0
Project path: C:\dev\RF24
Executing task: fmt

Run clang-format on C++ files.

By default, only changed C++ sources are formatted (uses `git status`).
The clang-format version is expected to be v14.
If v14 is not found, then an error is thrown.

Usage:
  > nur fmt {flags}

Flags:
  -a, --all: Format all C++ sources
  -h, --help: Display the help message for this command

Input/output types:
  ╭───┬───────┬────────╮
  │ # │ input │ output │
  ├───┼───────┼────────┤
  │ 0 │ any   │ any    │
  ╰───┴───────┴────────╯


Task execution successful
```

</p>
</details> 
