### PR TITLE
Fix RP2 Memory Leak

### DIFF
--- a/RF24.cpp
+++ b/RF24.cpp
@@ -993,6 +993,9 @@ bool RF24::begin(void)
     _spi->begin(csn_pin);
 
 #elif defined(RF24_RP2)
+    if(_spi != nullptr){
+        delete _spi;
+    }
     _spi = new SPI();
     _spi->begin(PICO_DEFAULT_SPI ? spi1 : spi0);
 

--- a/RF24.cpp
+++ b/RF24.cpp
@@ -993,7 +993,7 @@ bool RF24::begin(void)
     _spi->begin(csn_pin);
 
 #elif defined(RF24_RP2)
-    if(_spi != nullptr){
+    if (_spi != nullptr) {
         delete _spi;
     }
     _spi = new SPI();


### PR DESCRIPTION
If calling begin() multiple times on RP2 (Pico) the spi object was allocated but never deleted causing a memory leak