### PR TITLE
Exclude utility/pigpio from PlatformIO package export

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,6 +26,7 @@
             "utility/LittleWire/*",
             "utility/RPi/*",
             "utility/SPIDEV/*",
+            "utility/pigpio/*",
             "utility/rp2/*",
             "utility/ATXMegaD3/*"
         ]


### PR DESCRIPTION
**Summary**

`library.json`'s  `export.exclude`  strips every Linux/SBC-specific backend under  `utility/`  from the packaged PlatformIO library -  wiringPi ,  MRAA ,  LittleWire ,  RPi ,  SPIDEV ,  rp2 ,  ATXMegaD3  - but  utility/pigpio  was missed. This one-line change adds it, consistent with the sibling backends.

**Why it matters**

`utility/pigpio/{compatibility,gpio,interrupt,spi}.cpp`  `#include <pigpio.h>`, a Raspberry-Pi–only dependency. Because it isn't excluded, it ships in the packaged library and is the only remaining  `utility/` backend with .cpp sources that a non-LDF consumer will try to compile.

- On classic PlatformIO this is harmless: the Library Dependency Finder (LDF) prunes those files via the `#if !defined(ARDUINO)` guards, so they're never compiled on Arduino targets.
- On build systems that compile all packaged sources without running the LDF, the pigpio backend gets force-compiled and the build fails with  fatal error: `pigpio.h: No such file or directory`.

A concrete case is ESPHome on ESP32: current ESPHome builds the Arduino framework through the IDF-based `pioarduino` platform, whose PlatformIO -> ESP-IDF converter globs every source file in a dependency (no LDF). Pulling RF24 via lib_deps  / `cg.add_library("nRF24/RF24")`  therefore compiles `utility/pigpio/*.cpp` and fails on ESP32. ESP8266 (classic PlatformIO) is unaffected.